### PR TITLE
Complete EurKEY v1.1 mappings

### DIFF
--- a/EurKEY.keylayout
+++ b/EurKEY.keylayout
@@ -1024,6 +1024,7 @@
             <when state="none" output=" "/>
             <when state="dead: ^" output="^"/>
             <when state="dead: `" output="`"/>
+            <when state="dead: ¨" output="¨"/>
             <when state="dead: ˚" output="˚"/>
         </action>
         <action id="9">
@@ -1036,6 +1037,7 @@
             <when state="none" output="A"/>
             <when state="dead: ^" output="Â"/>
             <when state="dead: `" output="À"/>
+            <when state="dead: ¨" output="Ä"/>
             <when state="dead: ˚" output="Å"/>
         </action>
         <action id="C">
@@ -1047,6 +1049,7 @@
             <when state="none" output="E"/>
             <when state="dead: ^" output="Ê"/>
             <when state="dead: `" output="È"/>
+            <when state="dead: ¨" output="Ë"/>
             <when state="dead: ˚" output="Ė"/>
         </action>
         <action id="G">
@@ -1062,6 +1065,7 @@
             <when state="none" output="I"/>
             <when state="dead: ^" output="Î"/>
             <when state="dead: `" output="Ì"/>
+            <when state="dead: ¨" output="Ï"/>
             <when state="dead: ˚" output="İ"/>
         </action>
         <action id="J">
@@ -1072,6 +1076,7 @@
             <when state="none" output="O"/>
             <when state="dead: ^" output="Ô"/>
             <when state="dead: `" output="Ò"/>
+            <when state="dead: ¨" output="Ö"/>
         </action>
         <action id="S">
             <when state="none" output="S"/>
@@ -1081,6 +1086,7 @@
             <when state="none" output="U"/>
             <when state="dead: ^" output="Û"/>
             <when state="dead: `" output="Ù"/>
+            <when state="dead: ¨" output="Ü"/>
             <when state="dead: ˚" output="Ů"/>
         </action>
         <action id="W">
@@ -1090,6 +1096,7 @@
         <action id="Y">
             <when state="none" output="Y"/>
             <when state="dead: ^" output="Ŷ"/>
+            <when state="dead: ¨" output="Ÿ"/>
         </action>
         <action id="Z">
             <when state="none" output="Z"/>
@@ -1105,6 +1112,7 @@
             <when state="none" output="a"/>
             <when state="dead: ^" output="â"/>
             <when state="dead: `" output="à"/>
+            <when state="dead: ¨" output="ä"/>
             <when state="dead: ˚" output="å"/>
         </action>
         <action id="c">
@@ -1116,6 +1124,7 @@
             <when state="none" output="e"/>
             <when state="dead: ^" output="ê"/>
             <when state="dead: `" output="è"/>
+            <when state="dead: ¨" output="ë"/>
             <when state="dead: ˚" output="ė"/>
         </action>
         <action id="g">
@@ -1131,6 +1140,7 @@
             <when state="none" output="i"/>
             <when state="dead: ^" output="î"/>
             <when state="dead: `" output="ì"/>
+            <when state="dead: ¨" output="ï"/>
         </action>
         <action id="j">
             <when state="none" output="j"/>
@@ -1140,6 +1150,7 @@
             <when state="none" output="o"/>
             <when state="dead: ^" output="ô"/>
             <when state="dead: `" output="ò"/>
+            <when state="dead: ¨" output="ö"/>
         </action>
         <action id="s">
             <when state="none" output="s"/>
@@ -1149,6 +1160,7 @@
             <when state="none" output="u"/>
             <when state="dead: ^" output="û"/>
             <when state="dead: `" output="ù"/>
+            <when state="dead: ¨" output="ü"/>
             <when state="dead: ˚" output="ů"/>
         </action>
         <action id="w">
@@ -1159,6 +1171,7 @@
         <action id="y">
             <when state="none" output="y"/>
             <when state="dead: ^" output="ŷ"/>
+            <when state="dead: ¨" output="ÿ"/>
             <when state="dead: ˚" output="ẙ"/>
         </action>
         <action id="z">

--- a/EurKEY.keylayout
+++ b/EurKEY.keylayout
@@ -91,7 +91,7 @@
             <key code="46" action="m"/>
             <key code="47" output="."/>
             <key code="48" output="&#x0009;"/>
-            <key code="49" action="5"/>
+            <key code="49" action="space"/>
             <key code="50" output="`"/>
             <key code="51" output="&#x0008;"/>
             <key code="52" output="&#x0003;"/>
@@ -203,7 +203,7 @@
             <key code="46" action="M"/>
             <key code="47" output="&#x003E;"/>
             <key code="48" output="&#x0009;"/>
-            <key code="49" action="5"/>
+            <key code="49" action="space"/>
             <key code="50" output="~"/>
             <key code="51" output="&#x0008;"/>
             <key code="52" output="&#x0003;"/>
@@ -315,7 +315,7 @@
             <key code="46" action="M"/>
             <key code="47" output="."/>
             <key code="48" output="&#x0009;"/>
-            <key code="49" action="5"/>
+            <key code="49" action="space"/>
             <key code="50" output="`"/>
             <key code="51" output="&#x0008;"/>
             <key code="52" output="&#x0003;"/>
@@ -875,7 +875,7 @@
             <key code="46" output="&#x000D;"/>
             <key code="47" output="."/>
             <key code="48" output="&#x0009;"/>
-            <key code="49" action="5"/>
+            <key code="49" action="space"/>
             <key code="50" output="`"/>
             <key code="51" output="&#x0008;"/>
             <key code="52" output="&#x0003;"/>
@@ -948,8 +948,8 @@
             <key code="93" output="¥"/>
             <key code="94" output="_"/>
             <key code="95" output=","/>
-            <key code="102" action="5"/>
-            <key code="104" action="5"/>
+            <key code="102" action="space"/>
+            <key code="104" action="space"/>
         </keyMap>
         <keyMap index="1" baseMapSet="16c" baseIndex="1">
             <key code="19" output="&#x0022;"/>
@@ -968,8 +968,8 @@
             <key code="93" output="|"/>
             <key code="94" output="_"/>
             <key code="95" output=","/>
-            <key code="102" action="5"/>
-            <key code="104" action="5"/>
+            <key code="102" action="space"/>
+            <key code="104" action="space"/>
         </keyMap>
         <keyMap index="2" baseMapSet="16c" baseIndex="2">
             <key code="24" output="^"/>
@@ -980,43 +980,43 @@
             <key code="93" output="¥"/>
             <key code="94" output="_"/>
             <key code="95" output=","/>
-            <key code="102" action="5"/>
-            <key code="104" action="5"/>
+            <key code="102" action="space"/>
+            <key code="104" action="space"/>
         </keyMap>
         <keyMap index="3" baseMapSet="16c" baseIndex="3">
             <key code="93" output="\"/>
             <key code="94" action="`"/>
             <key code="95" output=","/>
-            <key code="102" action="5"/>
-            <key code="104" action="5"/>
+            <key code="102" action="space"/>
+            <key code="104" action="space"/>
         </keyMap>
         <keyMap index="4" baseMapSet="16c" baseIndex="4">
             <key code="93" output="|"/>
             <key code="94" output="`"/>
             <key code="95" output=","/>
-            <key code="102" action="5"/>
-            <key code="104" action="5"/>
+            <key code="102" action="space"/>
+            <key code="104" action="space"/>
         </keyMap>
         <keyMap index="5" baseMapSet="16c" baseIndex="5">
             <key code="93" output="\"/>
             <key code="94" output="`"/>
             <key code="95" output=","/>
-            <key code="102" action="5"/>
-            <key code="104" action="5"/>
+            <key code="102" action="space"/>
+            <key code="104" action="space"/>
         </keyMap>
         <keyMap index="6" baseMapSet="16c" baseIndex="6">
             <key code="93" output="\"/>
             <key code="94" output="_"/>
             <key code="95" output=","/>
-            <key code="102" action="5"/>
-            <key code="104" action="5"/>
+            <key code="102" action="space"/>
+            <key code="104" action="space"/>
         </keyMap>
         <keyMap index="7" baseMapSet="16c" baseIndex="7">
             <key code="93" output="|"/>
             <key code="94" output="_"/>
             <key code="95" output=","/>
-            <key code="102" action="5"/>
-            <key code="104" action="5"/>
+            <key code="102" action="space"/>
+            <key code="104" action="space"/>
         </keyMap>
     </keyMapSet>
     <actions>
@@ -1031,17 +1031,6 @@
         <action id="3">
             <when state="none" output="3"/>
             <when state="dead: ¯" output="—"/>
-        </action>
-        <action id="5">
-            <when state="none" output=" "/>
-            <when state="dead: ^" output="^"/>
-            <when state="dead: `" output="`"/>
-            <when state="dead: ~" output="~"/>
-            <when state="dead: ¨" output="¨"/>
-            <when state="dead: ¯" output="¯"/>
-            <when state="dead: ´" output="´"/>
-            <when state="dead: ˇ" output="ˇ"/>
-            <when state="dead: ˚" output="˚"/>
         </action>
         <action id="9">
             <when state="none" output="N"/>
@@ -1307,6 +1296,17 @@
             <when state="dead: ^" output="ŝ"/>
             <when state="dead: ´" output="ś"/>
             <when state="dead: ˇ" output="š"/>
+        </action>
+        <action id="space">
+            <when state="none" output=" "/>
+            <when state="dead: ^" output="^"/>
+            <when state="dead: `" output="`"/>
+            <when state="dead: ~" output="~"/>
+            <when state="dead: ¨" output="¨"/>
+            <when state="dead: ¯" output="¯"/>
+            <when state="dead: ´" output="´"/>
+            <when state="dead: ˇ" output="ˇ"/>
+            <when state="dead: ˚" output="˚"/>
         </action>
         <action id="t">
             <when state="none" output="t"/>

--- a/EurKEY.keylayout
+++ b/EurKEY.keylayout
@@ -63,10 +63,10 @@
             <key code="18" action="1"/>
             <key code="19" action="2"/>
             <key code="20" action="3"/>
-            <key code="21" output="4"/>
+            <key code="21" action="4"/>
             <key code="22" output="6"/>
-            <key code="23" output="5"/>
-            <key code="24" output="="/>
+            <key code="23" action="5"/>
+            <key code="24" action="="/>
             <key code="25" output="9"/>
             <key code="26" output="7"/>
             <key code="27" output="-"/>
@@ -178,7 +178,7 @@
             <key code="21" output="$"/>
             <key code="22" output="^"/>
             <key code="23" output="%"/>
-            <key code="24" output="+"/>
+            <key code="24" action="+"/>
             <key code="25" output="("/>
             <key code="26" output="&#x0026;"/>
             <key code="27" output="_"/>
@@ -284,13 +284,13 @@
             <key code="15" action="R"/>
             <key code="16" action="Y"/>
             <key code="17" action="T"/>
-            <key code="18" output="1"/>
-            <key code="19" output="2"/>
-            <key code="20" output="3"/>
-            <key code="21" output="4"/>
+            <key code="18" action="1"/>
+            <key code="19" action="2"/>
+            <key code="20" action="3"/>
+            <key code="21" action="4"/>
             <key code="22" output="6"/>
-            <key code="23" output="5"/>
-            <key code="24" output="="/>
+            <key code="23" action="5"/>
+            <key code="24" action="="/>
             <key code="25" output="9"/>
             <key code="26" output="7"/>
             <key code="27" output="-"/>
@@ -850,7 +850,7 @@
             <key code="21" output="4"/>
             <key code="22" output="6"/>
             <key code="23" output="5"/>
-            <key code="24" output="="/>
+            <key code="24" action="="/>
             <key code="25" output="9"/>
             <key code="26" output="7"/>
             <key code="27" output="&#x001F;"/>
@@ -1020,29 +1020,50 @@
         </keyMap>
     </keyMapSet>
     <actions>
+        <action id="+">
+            <when state="none" output="+"/>
+            <when state="dead: ©" output="⇔"/>
+        </action>
         <action id="1">
             <when state="none" output="1"/>
+            <when state="dead: ©" output="¼"/>
             <when state="dead: ¯" output="‐"/>
         </action>
         <action id="2">
             <when state="none" output="2"/>
+            <when state="dead: ©" output="½"/>
             <when state="dead: ¯" output="–"/>
         </action>
         <action id="3">
             <when state="none" output="3"/>
+            <when state="dead: ©" output="¾"/>
             <when state="dead: ¯" output="—"/>
+        </action>
+        <action id="4">
+            <when state="none" output="4"/>
+            <when state="dead: ©" output="⅓"/>
+        </action>
+        <action id="5">
+            <when state="none" output="5"/>
+            <when state="dead: ©" output="⅔"/>
         </action>
         <action id="9">
             <when state="none" output="N"/>
             <when state="dead: ~" output="Ñ"/>
+            <when state="dead: ©" output="⇙"/>
             <when state="dead: ´" output="Ń"/>
             <when state="dead: ˇ" output="Ň"/>
         </action>
         <action id="16">
             <when state="none" output="n"/>
             <when state="dead: ~" output="ñ"/>
+            <when state="dead: ©" output="↙"/>
             <when state="dead: ´" output="ń"/>
             <when state="dead: ˇ" output="ň"/>
+        </action>
+        <action id="=">
+            <when state="none" output="="/>
+            <when state="dead: ©" output="↔"/>
         </action>
         <action id="A">
             <when state="none" output="A"/>
@@ -1062,6 +1083,7 @@
         <action id="C">
             <when state="none" output="C"/>
             <when state="dead: ^" output="Ĉ"/>
+            <when state="dead: ©" output="©"/>
             <when state="dead: ´" output="Ć"/>
             <when state="dead: ˇ" output="Č"/>
             <when state="dead: ˚" output="Ċ"/>
@@ -1092,6 +1114,7 @@
         <action id="H">
             <when state="none" output="H"/>
             <when state="dead: ^" output="Ĥ"/>
+            <when state="dead: ©" output="⇐"/>
             <when state="dead: ¯" output="Ħ"/>
             <when state="dead: ˇ" output="Ȟ"/>
         </action>
@@ -1101,6 +1124,7 @@
             <when state="dead: `" output="Ì"/>
             <when state="dead: ~" output="Ĩ"/>
             <when state="dead: ¨" output="Ï"/>
+            <when state="dead: ©" output="⇗"/>
             <when state="dead: ¯" output="Ī"/>
             <when state="dead: ´" output="Í"/>
             <when state="dead: ˇ" output="Ǐ"/>
@@ -1109,20 +1133,24 @@
         <action id="J">
             <when state="none" output="J"/>
             <when state="dead: ^" output="Ĵ"/>
+            <when state="dead: ©" output="⇓"/>
         </action>
         <action id="K">
             <when state="none" output="K"/>
+            <when state="dead: ©" output="⇑"/>
             <when state="dead: ´" output="Ḱ"/>
             <when state="dead: ˇ" output="Ǩ"/>
         </action>
         <action id="L">
             <when state="none" output="L"/>
+            <when state="dead: ©" output="⇒"/>
             <when state="dead: ¯" output="Ḻ"/>
             <when state="dead: ´" output="Ł"/>
             <when state="dead: ˇ" output="Ľ"/>
         </action>
         <action id="M">
             <when state="none" output="M"/>
+            <when state="dead: ©" output="⇘"/>
             <when state="dead: ´" output="Ḿ"/>
         </action>
         <action id="O">
@@ -1137,21 +1165,25 @@
         </action>
         <action id="P">
             <when state="none" output="P"/>
+            <when state="dead: ©" output="℗"/>
             <when state="dead: ´" output="Ṕ"/>
         </action>
         <action id="R">
             <when state="none" output="R"/>
+            <when state="dead: ©" output="®"/>
             <when state="dead: ´" output="Ŕ"/>
             <when state="dead: ˇ" output="Ř"/>
         </action>
         <action id="S">
             <when state="none" output="S"/>
             <when state="dead: ^" output="Ŝ"/>
+            <when state="dead: ©" output="℠"/>
             <when state="dead: ´" output="Ś"/>
             <when state="dead: ˇ" output="Š"/>
         </action>
         <action id="T">
             <when state="none" output="T"/>
+            <when state="dead: ©" output="™"/>
             <when state="dead: ¯" output="Ŧ"/>
             <when state="dead: ˇ" output="Ť"/>
         </action>
@@ -1161,6 +1193,7 @@
             <when state="dead: `" output="Ù"/>
             <when state="dead: ~" output="Ũ"/>
             <when state="dead: ¨" output="Ü"/>
+            <when state="dead: ©" output="⇖"/>
             <when state="dead: ¯" output="Ū"/>
             <when state="dead: ´" output="Ú"/>
             <when state="dead: ˇ" output="Ǔ"/>
@@ -1209,6 +1242,7 @@
         <action id="c">
             <when state="none" output="c"/>
             <when state="dead: ^" output="ĉ"/>
+            <when state="dead: ©" output="©"/>
             <when state="dead: ´" output="ć"/>
             <when state="dead: ˇ" output="č"/>
             <when state="dead: ˚" output="ċ"/>
@@ -1239,6 +1273,7 @@
         <action id="h">
             <when state="none" output="h"/>
             <when state="dead: ^" output="ĥ"/>
+            <when state="dead: ©" output="←"/>
             <when state="dead: ¯" output="ħ"/>
             <when state="dead: ˇ" output="ȟ"/>
         </action>
@@ -1248,6 +1283,7 @@
             <when state="dead: `" output="ì"/>
             <when state="dead: ~" output="ĩ"/>
             <when state="dead: ¨" output="ï"/>
+            <when state="dead: ©" output="↗"/>
             <when state="dead: ¯" output="ī"/>
             <when state="dead: ´" output="í"/>
             <when state="dead: ˇ" output="ǐ"/>
@@ -1255,21 +1291,25 @@
         <action id="j">
             <when state="none" output="j"/>
             <when state="dead: ^" output="ĵ"/>
+            <when state="dead: ©" output="↓"/>
             <when state="dead: ˇ" output="ǰ"/>
         </action>
         <action id="k">
             <when state="none" output="k"/>
+            <when state="dead: ©" output="↑"/>
             <when state="dead: ´" output="ḱ"/>
             <when state="dead: ˇ" output="ǩ"/>
         </action>
         <action id="l">
             <when state="none" output="l"/>
+            <when state="dead: ©" output="→"/>
             <when state="dead: ¯" output="ḻ"/>
             <when state="dead: ´" output="ł"/>
             <when state="dead: ˇ" output="ľ"/>
         </action>
         <action id="m">
             <when state="none" output="m"/>
+            <when state="dead: ©" output="↘"/>
             <when state="dead: ´" output="ḿ"/>
         </action>
         <action id="o">
@@ -1284,16 +1324,19 @@
         </action>
         <action id="p">
             <when state="none" output="p"/>
+            <when state="dead: ©" output="℗"/>
             <when state="dead: ´" output="ṕ"/>
         </action>
         <action id="r">
             <when state="none" output="r"/>
+            <when state="dead: ©" output="®"/>
             <when state="dead: ´" output="ŕ"/>
             <when state="dead: ˇ" output="ř"/>
         </action>
         <action id="s">
             <when state="none" output="s"/>
             <when state="dead: ^" output="ŝ"/>
+            <when state="dead: ©" output="℠"/>
             <when state="dead: ´" output="ś"/>
             <when state="dead: ˇ" output="š"/>
         </action>
@@ -1303,6 +1346,7 @@
             <when state="dead: `" output="`"/>
             <when state="dead: ~" output="~"/>
             <when state="dead: ¨" output="¨"/>
+            <when state="dead: ©" output="©"/>
             <when state="dead: ¯" output="¯"/>
             <when state="dead: ´" output="´"/>
             <when state="dead: ˇ" output="ˇ"/>
@@ -1310,6 +1354,7 @@
         </action>
         <action id="t">
             <when state="none" output="t"/>
+            <when state="dead: ©" output="™"/>
             <when state="dead: ¯" output="ŧ"/>
             <when state="dead: ˇ" output="ť"/>
         </action>
@@ -1319,6 +1364,7 @@
             <when state="dead: `" output="ù"/>
             <when state="dead: ~" output="ũ"/>
             <when state="dead: ¨" output="ü"/>
+            <when state="dead: ©" output="↖"/>
             <when state="dead: ¯" output="ū"/>
             <when state="dead: ´" output="ú"/>
             <when state="dead: ˇ" output="ǔ"/>

--- a/EurKEY.keylayout
+++ b/EurKEY.keylayout
@@ -602,62 +602,62 @@
             <key code="126" output="&#x001E;"/>
         </keyMap>
         <keyMap index="5">
-            <key code="0" output="Å"/>
-            <key code="1" output="Í"/>
-            <key code="2" output="Î"/>
-            <key code="3" output="Ï"/>
-            <key code="4" output="Ó"/>
-            <key code="5" output="©"/>
-            <key code="6" output="Ω"/>
-            <key code="7" output="≈"/>
+            <key code="0" output="Ä"/>
+            <key code="1" output="ß"/>
+            <key code="2" output="Ð"/>
+            <key code="3" output="È"/>
+            <key code="4" output="Ù"/>
+            <key code="5" output="É"/>
+            <key code="6" output="À"/>
+            <key code="7" output="Á"/>
             <key code="8" output="Ç"/>
-            <key code="9" output="√"/>
+            <key code="9" output="Ì"/>
             <key code="10" output="§"/>
-            <key code="11" output="ı"/>
-            <key code="12" output="Œ"/>
-            <key code="13" output="∑"/>
-            <key code="14" output="´"/>
-            <key code="15" output="®"/>
-            <key code="16" output="Á"/>
-            <key code="17" output="†"/>
+            <key code="11" output="Í"/>
+            <key code="12" output="Æ"/>
+            <key code="13" output="Å"/>
+            <key code="14" output="Ë"/>
+            <key code="15" output="Ý"/>
+            <key code="16" output="Ÿ"/>
+            <key code="17" output="Þ"/>
             <key code="18" output="¡"/>
-            <key code="19" output="™"/>
-            <key code="20" output="£"/>
-            <key code="21" output="¢"/>
-            <key code="22" output="§"/>
-            <key code="23" output="∞"/>
-            <key code="24" output="≠"/>
-            <key code="25" output="ª"/>
-            <key code="26" output="¶"/>
-            <key code="27" output="–"/>
-            <key code="28" output="•"/>
-            <key code="29" output="º"/>
-            <key code="30" output="‘"/>
-            <key code="31" output="Ø"/>
-            <key code="32" output="¨"/>
-            <key code="33" output="“"/>
-            <key code="34" output="ˆ"/>
-            <key code="35" output="∏"/>
+            <key code="19" output="ª"/>
+            <key code="20" output="º"/>
+            <key code="21" output="£"/>
+            <key code="22" action="^"/>
+            <key code="23" output="€"/>
+            <key code="24" output="×"/>
+            <key code="25" output="“"/>
+            <key code="26" action="˚"/>
+            <key code="27" action="©"/>
+            <key code="28" output="„"/>
+            <key code="29" output="”"/>
+            <key code="30" output="»"/>
+            <key code="31" output="Ö"/>
+            <key code="32" output="Ü"/>
+            <key code="33" output="«"/>
+            <key code="34" output="Ï"/>
+            <key code="35" output="Œ"/>
             <key code="36" output="&#x000D;"/>
-            <key code="37" output="Ò"/>
-            <key code="38" output="Ô"/>
-            <key code="39" output="Æ"/>
-            <key code="40" output="˚"/>
-            <key code="41" output="…"/>
-            <key code="42" output="«"/>
-            <key code="43" output="≤"/>
-            <key code="44" output="÷"/>
-            <key code="45" output="˜"/>
-            <key code="46" output="Â"/>
-            <key code="47" output="≥"/>
+            <key code="37" output="Ø"/>
+            <key code="38" output="Ú"/>
+            <key code="39" action="´"/>
+            <key code="40" output="Ĳ"/>
+            <key code="41" action="¨"/>
+            <key code="42" output="¬"/>
+            <key code="43" output="Ò"/>
+            <key code="44" output="¿"/>
+            <key code="45" output="Ñ"/>
+            <key code="46" action="Ω"/>
+            <key code="47" output="Ó"/>
             <key code="48" output="&#x0009;"/>
             <key code="49" output=" "/>
-            <key code="50" output="`"/>
+            <key code="50" action="`"/>
             <key code="51" output="&#x0008;"/>
             <key code="52" output="&#x0003;"/>
             <key code="53" output="&#x001B;"/>
             <key code="64" output="&#x0010;"/>
-            <key code="65" output="."/>
+            <key code="65" output=","/>
             <key code="66" output="&#x001D;"/>
             <key code="67" output="*"/>
             <key code="69" output="+"/>

--- a/EurKEY.keylayout
+++ b/EurKEY.keylayout
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE keyboard PUBLIC "" "file://localhost/System/Library/DTDs/KeyboardLayout.dtd">
-<!--Last edited by Ukelele version 2.2.4 on 2013-07-03 at 20:15 (MESZ)-->
-<!--Created by Ukelele version 2.2.4 on 2013-07-01 at 20:44 (MESZ)-->
-<keyboard group="0" id="14844" name="EurKEY" maxout="1">
+<keyboard group="0" id="14844" name="U.S." maxout="1">
     <layouts>
         <layout first="0" last="17" modifiers="f4" mapSet="16c"/>
         <layout first="18" last="18" modifiers="f4" mapSet="994"/>
@@ -206,7 +204,7 @@
             <key code="47" output="&#x003E;"/>
             <key code="48" output="&#x0009;"/>
             <key code="49" action="5"/>
-            <key code="50" action="~"/>
+            <key code="50" output="~"/>
             <key code="51" output="&#x0008;"/>
             <key code="52" output="&#x0003;"/>
             <key code="53" output="&#x001B;"/>
@@ -380,57 +378,57 @@
             <key code="126" output="&#x001E;"/>
         </keyMap>
         <keyMap index="3">
-            <key code="0" output="ä"/>
+            <key code="0" output="å"/>
             <key code="1" output="ß"/>
             <key code="2" output="∂"/>
-            <key code="3" output="è"/>
-            <key code="4" output="ù"/>
-            <key code="5" output="é"/>
-            <key code="6" output="à"/>
-            <key code="7" output="á"/>
+            <key code="3" output="ƒ"/>
+            <key code="4" output="˙"/>
+            <key code="5" output="©"/>
+            <key code="6" output="Ω"/>
+            <key code="7" output="≈"/>
             <key code="8" output="ç"/>
-            <key code="9" output="ì"/>
+            <key code="9" output="√"/>
             <key code="10" output="§"/>
-            <key code="11" output="í"/>
-            <key code="12" output="æ"/>
-            <key code="13" output="å"/>
-            <key code="14" output="ë"/>
-            <key code="15" output="ý"/>
-            <key code="16" output="ÿ"/>
-            <key code="17" output="þ"/>
+            <key code="11" output="∫"/>
+            <key code="12" output="œ"/>
+            <key code="13" output="∑"/>
+            <key code="14" action="0"/>
+            <key code="15" output="®"/>
+            <key code="16" output="¥"/>
+            <key code="17" output="†"/>
             <key code="18" output="¡"/>
-            <key code="19" output="ª"/>
-            <key code="20" output="˚"/>
-            <key code="21" output="€"/>
-            <key code="22" action="§"/>
-            <key code="23" output="£"/>
-            <key code="24" output="⨉"/>
-            <key code="25" output="“"/>
-            <key code="26" action="¶"/>
-            <key code="27" action="©"/>
-            <key code="28" output="„"/>
-            <key code="29" output="”"/>
-            <key code="30" output="≫"/>
-            <key code="31" output="ö"/>
-            <key code="32" output="ü"/>
-            <key code="33" output="≪"/>
-            <key code="34" output="ï"/>
-            <key code="35" output="œ"/>
+            <key code="19" output="™"/>
+            <key code="20" output="£"/>
+            <key code="21" output="¢"/>
+            <key code="22" output="§"/>
+            <key code="23" output="∞"/>
+            <key code="24" output="≠"/>
+            <key code="25" output="ª"/>
+            <key code="26" output="¶"/>
+            <key code="27" output="–"/>
+            <key code="28" output="•"/>
+            <key code="29" output="º"/>
+            <key code="30" output="‘"/>
+            <key code="31" output="ø"/>
+            <key code="32" action="3"/>
+            <key code="33" output="“"/>
+            <key code="34" action="2"/>
+            <key code="35" output="π"/>
             <key code="36" output="&#x000D;"/>
-            <key code="37" output="ø"/>
-            <key code="38" output="ú"/>
-            <key code="39" action="æ"/>
-            <key code="40" output="ĳ"/>
-            <key code="41" action="…"/>
-            <key code="42" output="¬"/>
-            <key code="43" output="ò"/>
+            <key code="37" output="¬"/>
+            <key code="38" output="∆"/>
+            <key code="39" output="æ"/>
+            <key code="40" output="˚"/>
+            <key code="41" output="…"/>
+            <key code="42" output="«"/>
+            <key code="43" output="≤"/>
             <key code="44" output="÷"/>
-            <key code="45" output="ñ"/>
-            <key code="46" action="Ω"/>
-            <key code="47" output="ó"/>
+            <key code="45" action="4"/>
+            <key code="46" output="µ"/>
+            <key code="47" output="≥"/>
             <key code="48" output="&#x0009;"/>
             <key code="49" output=" "/>
-            <key code="50" action="`"/>
+            <key code="50" action="1"/>
             <key code="51" output="&#x0008;"/>
             <key code="52" output="&#x0003;"/>
             <key code="53" output="&#x001B;"/>
@@ -492,57 +490,57 @@
             <key code="126" output="&#x001E;"/>
         </keyMap>
         <keyMap index="4">
-            <key code="0" output="Ä"/>
+            <key code="0" output="Å"/>
             <key code="1" output="Í"/>
             <key code="2" output="Î"/>
-            <key code="3" output="È"/>
-            <key code="4" output="Ù"/>
-            <key code="5" output="É"/>
-            <key code="6" output="À"/>
-            <key code="7" output="Á"/>
+            <key code="3" output="Ï"/>
+            <key code="4" output="Ó"/>
+            <key code="5" output="˝"/>
+            <key code="6" output="¸"/>
+            <key code="7" output="˛"/>
             <key code="8" output="Ç"/>
-            <key code="9" output="Ì"/>
+            <key code="9" output="◊"/>
             <key code="10" output="±"/>
-            <key code="11" output="Í"/>
-            <key code="12" output="Æ"/>
-            <key code="13" output="Å"/>
-            <key code="14" output="Ë"/>
-            <key code="15" output="Ý"/>
-            <key code="16" output="Ÿ"/>
-            <key code="17" output="Þ"/>
-            <key code="18" output="¹"/>
-            <key code="19" output="²"/>
-            <key code="20" output="³"/>
-            <key code="21" output="¥"/>
-            <key code="22" output="˘"/>
-            <key code="23" output="¢"/>
-            <key code="24" output="÷"/>
-            <key code="25" output="‘"/>
+            <key code="11" output="ı"/>
+            <key code="12" output="Œ"/>
+            <key code="13" output="„"/>
+            <key code="14" output="´"/>
+            <key code="15" output="‰"/>
+            <key code="16" output="Á"/>
+            <key code="17" output="ˇ"/>
+            <key code="18" output="⁄"/>
+            <key code="19" output="€"/>
+            <key code="20" output="‹"/>
+            <key code="21" output="›"/>
+            <key code="22" output="ﬂ"/>
+            <key code="23" output="ﬁ"/>
+            <key code="24" output="±"/>
+            <key code="25" output="·"/>
             <key code="26" output="‡"/>
-            <key code="27" output="№"/>
-            <key code="28" output="‚"/>
-            <key code="29" output="’"/>
-            <key code="30" output="﹥"/>
-            <key code="31" output="Ö"/>
-            <key code="32" output="Ü"/>
-            <key code="33" output="﹤"/>
-            <key code="34" output="Ï"/>
-            <key code="35" output="Œ"/>
+            <key code="27" output="—"/>
+            <key code="28" output="°"/>
+            <key code="29" output="‚"/>
+            <key code="30" output="’"/>
+            <key code="31" output="Ø"/>
+            <key code="32" output="¨"/>
+            <key code="33" output="”"/>
+            <key code="34" output="ˆ"/>
+            <key code="35" output="∏"/>
             <key code="36" output="&#x000D;"/>
-            <key code="37" output="Ø"/>
-            <key code="38" output="Ú"/>
-            <key code="39" output="✝"/>
-            <key code="40" output="Ĳ"/>
-            <key code="41" output="·"/>
-            <key code="42" output="╎"/>
-            <key code="43" output="Ò"/>
-            <key code="44" output="…"/>
-            <key code="45" output="Ñ"/>
-            <key code="46" action="Â"/>
-            <key code="47" output="Ó"/>
+            <key code="37" output="Ò"/>
+            <key code="38" output="Ô"/>
+            <key code="39" output="Æ"/>
+            <key code="40" output=""/>
+            <key code="41" output="Ú"/>
+            <key code="42" output="»"/>
+            <key code="43" output="¯"/>
+            <key code="44" output="¿"/>
+            <key code="45" output="˜"/>
+            <key code="46" output="Â"/>
+            <key code="47" output="˘"/>
             <key code="48" output="&#x0009;"/>
             <key code="49" output=" "/>
-            <key code="50" action="` 1"/>
+            <key code="50" output="`"/>
             <key code="51" output="&#x0008;"/>
             <key code="52" output="&#x0003;"/>
             <key code="53" output="&#x001B;"/>
@@ -1022,168 +1020,125 @@
         </keyMap>
     </keyMapSet>
     <actions>
+        <action id="0">
+            <when state="none" next="s1"/>
+        </action>
         <action id="1">
             <when state="none" next="s2"/>
         </action>
+        <action id="2">
+            <when state="none" next="s3"/>
+        </action>
+        <action id="3">
+            <when state="none" next="s4"/>
+        </action>
+        <action id="4">
+            <when state="none" next="s5"/>
+        </action>
         <action id="5">
             <when state="none" output=" "/>
-            <when state="^" output="ˆ"/>
+            <when state="s1" output="´"/>
             <when state="s2" output="`"/>
-            <when state="~" output="˜"/>
-            <when state="¨" output="¨"/>
-            <when state="´" output="´"/>
+            <when state="s3" output="ˆ"/>
+            <when state="s4" output="¨"/>
+            <when state="s5" output="˜"/>
         </action>
         <action id="6">
             <when state="none" output="A"/>
-            <when state="^" output="Â"/>
-            <when state="`" output="À"/>
+            <when state="s1" output="Á"/>
             <when state="s2" output="À"/>
-            <when state="~" output="Ã"/>
-            <when state="¨" output="Ä"/>
-            <when state="´" output="Á"/>
+            <when state="s3" output="Â"/>
+            <when state="s4" output="Ä"/>
+            <when state="s5" output="Ã"/>
         </action>
         <action id="7">
             <when state="none" output="E"/>
-            <when state="^" output="Ê"/>
-            <when state="`" output="È"/>
+            <when state="s1" output="É"/>
             <when state="s2" output="È"/>
-            <when state="¨" output="Ë"/>
-            <when state="´" output="É"/>
+            <when state="s3" output="Ê"/>
+            <when state="s4" output="Ë"/>
         </action>
         <action id="8">
             <when state="none" output="I"/>
-            <when state="^" output="Î"/>
-            <when state="`" output="Ì"/>
+            <when state="s1" output="Í"/>
             <when state="s2" output="Ì"/>
-            <when state="¨" output="Ï"/>
-            <when state="´" output="Í"/>
+            <when state="s3" output="Î"/>
+            <when state="s4" output="Ï"/>
         </action>
         <action id="9">
             <when state="none" output="N"/>
-            <when state="~" output="Ñ"/>
+            <when state="s5" output="Ñ"/>
         </action>
         <action id="10">
             <when state="none" output="O"/>
-            <when state="^" output="Ô"/>
-            <when state="`" output="Ò"/>
+            <when state="s1" output="Ó"/>
             <when state="s2" output="Ò"/>
-            <when state="~" output="Õ"/>
-            <when state="¨" output="Ö"/>
-            <when state="´" output="Ó"/>
+            <when state="s3" output="Ô"/>
+            <when state="s4" output="Ö"/>
+            <when state="s5" output="Õ"/>
         </action>
         <action id="11">
             <when state="none" output="U"/>
-            <when state="^" output="Û"/>
-            <when state="`" output="Ù"/>
+            <when state="s1" output="Ú"/>
             <when state="s2" output="Ù"/>
-            <when state="¨" output="Ü"/>
-            <when state="´" output="Ú"/>
+            <when state="s3" output="Û"/>
+            <when state="s4" output="Ü"/>
         </action>
         <action id="12">
             <when state="none" output="Y"/>
-            <when state="`" output="Ỳ"/>
-            <when state="¨" output="Ÿ"/>
+            <when state="s4" output="Ÿ"/>
         </action>
         <action id="13">
             <when state="none" output="a"/>
-            <when state="^" output="â"/>
-            <when state="`" output="à"/>
+            <when state="s1" output="á"/>
             <when state="s2" output="à"/>
-            <when state="~" output="ã"/>
-            <when state="¨" output="ä"/>
-            <when state="´" output="á"/>
-            <when state="óld" output="á"/>
-            <when state="öld" output="ä"/>
-            <when state="˚" output="å"/>
+            <when state="s3" output="â"/>
+            <when state="s4" output="ä"/>
+            <when state="s5" output="ã"/>
         </action>
         <action id="14">
             <when state="none" output="e"/>
-            <when state="^" output="ê"/>
-            <when state="`" output="è"/>
+            <when state="s1" output="é"/>
             <when state="s2" output="è"/>
-            <when state="¨" output="ë"/>
-            <when state="´" output="é"/>
+            <when state="s3" output="ê"/>
+            <when state="s4" output="ë"/>
         </action>
         <action id="15">
             <when state="none" output="i"/>
-            <when state="^" output="î"/>
-            <when state="`" output="ì"/>
+            <when state="s1" output="í"/>
             <when state="s2" output="ì"/>
-            <when state="¨" output="ï"/>
-            <when state="´" output="í"/>
+            <when state="s3" output="î"/>
+            <when state="s4" output="ï"/>
         </action>
         <action id="16">
             <when state="none" output="n"/>
-            <when state="~" output="ñ"/>
+            <when state="s5" output="ñ"/>
         </action>
         <action id="17">
             <when state="none" output="o"/>
-            <when state="^" output="ô"/>
-            <when state="`" output="ò"/>
+            <when state="s1" output="ó"/>
             <when state="s2" output="ò"/>
-            <when state="~" output="õ"/>
-            <when state="¨" output="ö"/>
-            <when state="´" output="ó"/>
+            <when state="s3" output="ô"/>
+            <when state="s4" output="ö"/>
+            <when state="s5" output="õ"/>
         </action>
         <action id="18">
             <when state="none" output="u"/>
-            <when state="^" output="û"/>
-            <when state="`" output="ù"/>
+            <when state="s1" output="ú"/>
             <when state="s2" output="ù"/>
-            <when state="¨" output="ü"/>
-            <when state="´" output="ú"/>
+            <when state="s3" output="û"/>
+            <when state="s4" output="ü"/>
         </action>
         <action id="19">
             <when state="none" output="y"/>
-            <when state="`" output="ỳ"/>
-            <when state="¨" output="ÿ"/>
-        </action>
-        <action id="`">
-            <when state="none" next="`"/>
-        </action>
-        <action id="` 1">
-            <when state="none" next="old~"/>
-        </action>
-        <action id="~">
-            <when state="none" output="~"/>
-            <when state="`" output="`"/>
-        </action>
-        <action id="§">
-            <when state="none" next="old^"/>
-        </action>
-        <action id="©">
-            <when state="none" next="©"/>
-        </action>
-        <action id="¶">
-            <when state="none" next="˚"/>
-        </action>
-        <action id="Â">
-            <when state="none" next="±"/>
-        </action>
-        <action id="æ">
-            <when state="none" next="óld"/>
-        </action>
-        <action id="Ω">
-            <when state="none" next="Ω"/>
-        </action>
-        <action id="…">
-            <when state="none" next="öld"/>
+            <when state="s4" output="ÿ"/>
         </action>
     </actions>
     <terminators>
-        <when state="^" output="ˆ"/>
-        <when state="`" output="`"/>
-        <when state="old^" output="^"/>
-        <when state="old~" output="~"/>
+        <when state="s1" output="´"/>
         <when state="s2" output="`"/>
-        <when state="~" output="˜"/>
-        <when state="¨" output="¨"/>
-        <when state="©" output="©"/>
-        <when state="±" output="±"/>
-        <when state="´" output="´"/>
-        <when state="óld" output="´"/>
-        <when state="öld" output="¨"/>
-        <when state="˚" output="˚"/>
-        <when state="Ω" output="Ω"/>
+        <when state="s3" output="ˆ"/>
+        <when state="s4" output="¨"/>
+        <when state="s5" output="˜"/>
     </terminators>
 </keyboard>

--- a/EurKEY.keylayout
+++ b/EurKEY.keylayout
@@ -42,7 +42,7 @@
     </modifierMap>
     <keyMapSet id="16c">
         <keyMap index="0">
-            <key code="0" action="13"/>
+            <key code="0" action="a"/>
             <key code="1" output="s"/>
             <key code="2" output="d"/>
             <key code="3" output="f"/>
@@ -56,7 +56,7 @@
             <key code="11" output="b"/>
             <key code="12" output="q"/>
             <key code="13" output="w"/>
-            <key code="14" action="14"/>
+            <key code="14" action="e"/>
             <key code="15" output="r"/>
             <key code="16" action="19"/>
             <key code="17" output="t"/>
@@ -73,10 +73,10 @@
             <key code="28" output="8"/>
             <key code="29" output="0"/>
             <key code="30" output="]"/>
-            <key code="31" action="17"/>
-            <key code="32" action="18"/>
+            <key code="31" action="o"/>
+            <key code="32" action="u"/>
             <key code="33" output="["/>
-            <key code="34" action="15"/>
+            <key code="34" action="i"/>
             <key code="35" output="p"/>
             <key code="36" output="&#x000D;"/>
             <key code="37" output="l"/>
@@ -154,7 +154,7 @@
             <key code="126" output="&#x001E;"/>
         </keyMap>
         <keyMap index="1">
-            <key code="0" action="6"/>
+            <key code="0" action="A"/>
             <key code="1" output="S"/>
             <key code="2" output="D"/>
             <key code="3" output="F"/>
@@ -168,7 +168,7 @@
             <key code="11" output="B"/>
             <key code="12" output="Q"/>
             <key code="13" output="W"/>
-            <key code="14" action="7"/>
+            <key code="14" action="E"/>
             <key code="15" output="R"/>
             <key code="16" action="12"/>
             <key code="17" output="T"/>
@@ -185,10 +185,10 @@
             <key code="28" output="*"/>
             <key code="29" output=")"/>
             <key code="30" output="}"/>
-            <key code="31" action="10"/>
-            <key code="32" action="11"/>
+            <key code="31" action="O"/>
+            <key code="32" action="U"/>
             <key code="33" output="{"/>
-            <key code="34" action="8"/>
+            <key code="34" action="I"/>
             <key code="35" output="P"/>
             <key code="36" output="&#x000D;"/>
             <key code="37" output="L"/>
@@ -266,7 +266,7 @@
             <key code="126" output="&#x001E;"/>
         </keyMap>
         <keyMap index="2">
-            <key code="0" action="6"/>
+            <key code="0" action="A"/>
             <key code="1" output="S"/>
             <key code="2" output="D"/>
             <key code="3" output="F"/>
@@ -280,7 +280,7 @@
             <key code="11" output="B"/>
             <key code="12" output="Q"/>
             <key code="13" output="W"/>
-            <key code="14" action="7"/>
+            <key code="14" action="E"/>
             <key code="15" output="R"/>
             <key code="16" action="12"/>
             <key code="17" output="T"/>
@@ -297,10 +297,10 @@
             <key code="28" output="8"/>
             <key code="29" output="0"/>
             <key code="30" output="]"/>
-            <key code="31" action="10"/>
-            <key code="32" action="11"/>
+            <key code="31" action="O"/>
+            <key code="32" action="U"/>
             <key code="33" output="["/>
-            <key code="34" action="8"/>
+            <key code="34" action="I"/>
             <key code="35" output="P"/>
             <key code="36" output="&#x000D;"/>
             <key code="37" output="L"/>
@@ -985,7 +985,7 @@
         </keyMap>
         <keyMap index="3" baseMapSet="16c" baseIndex="3">
             <key code="93" output="\"/>
-            <key code="94" action="1"/>
+            <key code="94" action="`"/>
             <key code="95" output=","/>
             <key code="102" action="5"/>
             <key code="104" action="5"/>
@@ -1020,70 +1020,67 @@
         </keyMap>
     </keyMapSet>
     <actions>
-        <action id="1">
-            <when state="none" next="s2"/>
-        </action>
         <action id="5">
             <when state="none" output=" "/>
-            <when state="s2" output="`"/>
-        </action>
-        <action id="6">
-            <when state="none" output="A"/>
-            <when state="s2" output="À"/>
-        </action>
-        <action id="7">
-            <when state="none" output="E"/>
-            <when state="s2" output="È"/>
-        </action>
-        <action id="8">
-            <when state="none" output="I"/>
-            <when state="s2" output="Ì"/>
+            <when state="dead: `" output="`"/>
         </action>
         <action id="9">
             <when state="none" output="N"/>
         </action>
-        <action id="10">
-            <when state="none" output="O"/>
-            <when state="s2" output="Ò"/>
-        </action>
-        <action id="11">
-            <when state="none" output="U"/>
-            <when state="s2" output="Ù"/>
-        </action>
         <action id="12">
             <when state="none" output="Y"/>
-        </action>
-        <action id="13">
-            <when state="none" output="a"/>
-            <when state="s2" output="à"/>
-        </action>
-        <action id="14">
-            <when state="none" output="e"/>
-            <when state="s2" output="è"/>
-        </action>
-        <action id="15">
-            <when state="none" output="i"/>
-            <when state="s2" output="ì"/>
         </action>
         <action id="16">
             <when state="none" output="n"/>
         </action>
-        <action id="17">
-            <when state="none" output="o"/>
-            <when state="s2" output="ò"/>
-        </action>
-        <action id="18">
-            <when state="none" output="u"/>
-            <when state="s2" output="ù"/>
-        </action>
         <action id="19">
             <when state="none" output="y"/>
+        </action>
+        <action id="A">
+            <when state="none" output="A"/>
+            <when state="dead: `" output="À"/>
+        </action>
+        <action id="E">
+            <when state="none" output="E"/>
+            <when state="dead: `" output="È"/>
+        </action>
+        <action id="I">
+            <when state="none" output="I"/>
+            <when state="dead: `" output="Ì"/>
+        </action>
+        <action id="O">
+            <when state="none" output="O"/>
+            <when state="dead: `" output="Ò"/>
+        </action>
+        <action id="U">
+            <when state="none" output="U"/>
+            <when state="dead: `" output="Ù"/>
         </action>
         <action id="^">
             <when state="none" next="dead: ^"/>
         </action>
         <action id="`">
             <when state="none" next="dead: `"/>
+        </action>
+        <action id="a">
+            <when state="none" output="a"/>
+            <when state="dead: `" output="à"/>
+        </action>
+        <action id="e">
+            <when state="none" output="e"/>
+            <when state="dead: `" output="è"/>
+        </action>
+        <action id="i">
+            <when state="none" output="i"/>
+            <when state="dead: `" output="ì"/>
+        </action>
+        <action id="o">
+            <when state="none" output="o"/>
+            <when state="dead: `" output="ò"/>
+        </action>
+        <action id="u">
+            <when state="none" output="u"/>
+            <when state="dead: `" output="ù"/>
         </action>
         <action id="~">
             <when state="none" next="dead: ~"/>
@@ -1125,6 +1122,5 @@
         <when state="dead: ˚" output="˚"/>
         <when state="dead: Ω" output="Ω"/>
         <when state="dead: √" output=" "/>
-        <when state="s2" output="`"/>
     </terminators>
 </keyboard>

--- a/EurKEY.keylayout
+++ b/EurKEY.keylayout
@@ -44,7 +44,7 @@
         <keyMap index="0">
             <key code="0" action="a"/>
             <key code="1" action="s"/>
-            <key code="2" output="d"/>
+            <key code="2" action="d"/>
             <key code="3" output="f"/>
             <key code="4" action="h"/>
             <key code="5" action="g"/>
@@ -59,7 +59,7 @@
             <key code="14" action="e"/>
             <key code="15" action="r"/>
             <key code="16" action="y"/>
-            <key code="17" output="t"/>
+            <key code="17" action="t"/>
             <key code="18" output="1"/>
             <key code="19" output="2"/>
             <key code="20" output="3"/>
@@ -156,7 +156,7 @@
         <keyMap index="1">
             <key code="0" action="A"/>
             <key code="1" action="S"/>
-            <key code="2" output="D"/>
+            <key code="2" action="D"/>
             <key code="3" output="F"/>
             <key code="4" action="H"/>
             <key code="5" action="G"/>
@@ -171,7 +171,7 @@
             <key code="14" action="E"/>
             <key code="15" action="R"/>
             <key code="16" action="Y"/>
-            <key code="17" output="T"/>
+            <key code="17" action="T"/>
             <key code="18" output="!"/>
             <key code="19" output="@"/>
             <key code="20" output="#"/>
@@ -268,7 +268,7 @@
         <keyMap index="2">
             <key code="0" action="A"/>
             <key code="1" action="S"/>
-            <key code="2" output="D"/>
+            <key code="2" action="D"/>
             <key code="3" output="F"/>
             <key code="4" action="H"/>
             <key code="5" action="G"/>
@@ -283,7 +283,7 @@
             <key code="14" action="E"/>
             <key code="15" action="R"/>
             <key code="16" action="Y"/>
-            <key code="17" output="T"/>
+            <key code="17" action="T"/>
             <key code="18" output="1"/>
             <key code="19" output="2"/>
             <key code="20" output="3"/>
@@ -1027,17 +1027,20 @@
             <when state="dead: ~" output="~"/>
             <when state="dead: ¨" output="¨"/>
             <when state="dead: ´" output="´"/>
+            <when state="dead: ˇ" output="ˇ"/>
             <when state="dead: ˚" output="˚"/>
         </action>
         <action id="9">
             <when state="none" output="N"/>
             <when state="dead: ~" output="Ñ"/>
             <when state="dead: ´" output="Ń"/>
+            <when state="dead: ˇ" output="Ň"/>
         </action>
         <action id="16">
             <when state="none" output="n"/>
             <when state="dead: ~" output="ñ"/>
             <when state="dead: ´" output="ń"/>
+            <when state="dead: ˇ" output="ň"/>
         </action>
         <action id="A">
             <when state="none" output="A"/>
@@ -1046,6 +1049,7 @@
             <when state="dead: ~" output="Ã"/>
             <when state="dead: ¨" output="Ä"/>
             <when state="dead: ´" output="Á"/>
+            <when state="dead: ˇ" output="Ǎ"/>
             <when state="dead: ˚" output="Å"/>
         </action>
         <action id="B">
@@ -1056,7 +1060,12 @@
             <when state="none" output="C"/>
             <when state="dead: ^" output="Ĉ"/>
             <when state="dead: ´" output="Ć"/>
+            <when state="dead: ˇ" output="Č"/>
             <when state="dead: ˚" output="Ċ"/>
+        </action>
+        <action id="D">
+            <when state="none" output="D"/>
+            <when state="dead: ˇ" output="Ď"/>
         </action>
         <action id="E">
             <when state="none" output="E"/>
@@ -1064,17 +1073,20 @@
             <when state="dead: `" output="È"/>
             <when state="dead: ¨" output="Ë"/>
             <when state="dead: ´" output="É"/>
+            <when state="dead: ˇ" output="Ě"/>
             <when state="dead: ˚" output="Ė"/>
         </action>
         <action id="G">
             <when state="none" output="G"/>
             <when state="dead: ^" output="Ĝ"/>
             <when state="dead: ´" output="Ǵ"/>
+            <when state="dead: ˇ" output="Ǧ"/>
             <when state="dead: ˚" output="Ġ"/>
         </action>
         <action id="H">
             <when state="none" output="H"/>
             <when state="dead: ^" output="Ĥ"/>
+            <when state="dead: ˇ" output="Ȟ"/>
         </action>
         <action id="I">
             <when state="none" output="I"/>
@@ -1083,6 +1095,7 @@
             <when state="dead: ~" output="Ĩ"/>
             <when state="dead: ¨" output="Ï"/>
             <when state="dead: ´" output="Í"/>
+            <when state="dead: ˇ" output="Ǐ"/>
             <when state="dead: ˚" output="İ"/>
         </action>
         <action id="J">
@@ -1092,10 +1105,12 @@
         <action id="K">
             <when state="none" output="K"/>
             <when state="dead: ´" output="Ḱ"/>
+            <when state="dead: ˇ" output="Ǩ"/>
         </action>
         <action id="L">
             <when state="none" output="L"/>
             <when state="dead: ´" output="Ł"/>
+            <when state="dead: ˇ" output="Ľ"/>
         </action>
         <action id="M">
             <when state="none" output="M"/>
@@ -1108,6 +1123,7 @@
             <when state="dead: ~" output="Õ"/>
             <when state="dead: ¨" output="Ö"/>
             <when state="dead: ´" output="Ó"/>
+            <when state="dead: ˇ" output="Ǒ"/>
         </action>
         <action id="P">
             <when state="none" output="P"/>
@@ -1116,11 +1132,17 @@
         <action id="R">
             <when state="none" output="R"/>
             <when state="dead: ´" output="Ŕ"/>
+            <when state="dead: ˇ" output="Ř"/>
         </action>
         <action id="S">
             <when state="none" output="S"/>
             <when state="dead: ^" output="Ŝ"/>
             <when state="dead: ´" output="Ś"/>
+            <when state="dead: ˇ" output="Š"/>
+        </action>
+        <action id="T">
+            <when state="none" output="T"/>
+            <when state="dead: ˇ" output="Ť"/>
         </action>
         <action id="U">
             <when state="none" output="U"/>
@@ -1129,6 +1151,7 @@
             <when state="dead: ~" output="Ũ"/>
             <when state="dead: ¨" output="Ü"/>
             <when state="dead: ´" output="Ú"/>
+            <when state="dead: ˇ" output="Ǔ"/>
             <when state="dead: ˚" output="Ů"/>
         </action>
         <action id="W">
@@ -1146,6 +1169,7 @@
         <action id="Z">
             <when state="none" output="Z"/>
             <when state="dead: ´" output="Ź"/>
+            <when state="dead: ˇ" output="Ž"/>
             <when state="dead: ˚" output="Ż"/>
         </action>
         <action id="^">
@@ -1161,6 +1185,7 @@
             <when state="dead: ~" output="ã"/>
             <when state="dead: ¨" output="ä"/>
             <when state="dead: ´" output="á"/>
+            <when state="dead: ˇ" output="ǎ"/>
             <when state="dead: ˚" output="å"/>
         </action>
         <action id="b">
@@ -1171,7 +1196,12 @@
             <when state="none" output="c"/>
             <when state="dead: ^" output="ĉ"/>
             <when state="dead: ´" output="ć"/>
+            <when state="dead: ˇ" output="č"/>
             <when state="dead: ˚" output="ċ"/>
+        </action>
+        <action id="d">
+            <when state="none" output="d"/>
+            <when state="dead: ˇ" output="ď"/>
         </action>
         <action id="e">
             <when state="none" output="e"/>
@@ -1179,17 +1209,20 @@
             <when state="dead: `" output="è"/>
             <when state="dead: ¨" output="ë"/>
             <when state="dead: ´" output="é"/>
+            <when state="dead: ˇ" output="ě"/>
             <when state="dead: ˚" output="ė"/>
         </action>
         <action id="g">
             <when state="none" output="g"/>
             <when state="dead: ^" output="ĝ"/>
             <when state="dead: ´" output="ǵ"/>
+            <when state="dead: ˇ" output="ǧ"/>
             <when state="dead: ˚" output="ġ"/>
         </action>
         <action id="h">
             <when state="none" output="h"/>
             <when state="dead: ^" output="ĥ"/>
+            <when state="dead: ˇ" output="ȟ"/>
         </action>
         <action id="i">
             <when state="none" output="i"/>
@@ -1198,18 +1231,22 @@
             <when state="dead: ~" output="ĩ"/>
             <when state="dead: ¨" output="ï"/>
             <when state="dead: ´" output="í"/>
+            <when state="dead: ˇ" output="ǐ"/>
         </action>
         <action id="j">
             <when state="none" output="j"/>
             <when state="dead: ^" output="ĵ"/>
+            <when state="dead: ˇ" output="ǰ"/>
         </action>
         <action id="k">
             <when state="none" output="k"/>
             <when state="dead: ´" output="ḱ"/>
+            <when state="dead: ˇ" output="ǩ"/>
         </action>
         <action id="l">
             <when state="none" output="l"/>
             <when state="dead: ´" output="ł"/>
+            <when state="dead: ˇ" output="ľ"/>
         </action>
         <action id="m">
             <when state="none" output="m"/>
@@ -1222,6 +1259,7 @@
             <when state="dead: ~" output="õ"/>
             <when state="dead: ¨" output="ö"/>
             <when state="dead: ´" output="ó"/>
+            <when state="dead: ˇ" output="ǒ"/>
         </action>
         <action id="p">
             <when state="none" output="p"/>
@@ -1230,11 +1268,17 @@
         <action id="r">
             <when state="none" output="r"/>
             <when state="dead: ´" output="ŕ"/>
+            <when state="dead: ˇ" output="ř"/>
         </action>
         <action id="s">
             <when state="none" output="s"/>
             <when state="dead: ^" output="ŝ"/>
             <when state="dead: ´" output="ś"/>
+            <when state="dead: ˇ" output="š"/>
+        </action>
+        <action id="t">
+            <when state="none" output="t"/>
+            <when state="dead: ˇ" output="ť"/>
         </action>
         <action id="u">
             <when state="none" output="u"/>
@@ -1243,6 +1287,7 @@
             <when state="dead: ~" output="ũ"/>
             <when state="dead: ¨" output="ü"/>
             <when state="dead: ´" output="ú"/>
+            <when state="dead: ˇ" output="ǔ"/>
             <when state="dead: ˚" output="ů"/>
         </action>
         <action id="w">
@@ -1262,6 +1307,7 @@
         <action id="z">
             <when state="none" output="z"/>
             <when state="dead: ´" output="ź"/>
+            <when state="dead: ˇ" output="ž"/>
             <when state="dead: ˚" output="ż"/>
         </action>
         <action id="~">

--- a/EurKEY.keylayout
+++ b/EurKEY.keylayout
@@ -1024,22 +1024,26 @@
             <when state="none" output=" "/>
             <when state="dead: ^" output="^"/>
             <when state="dead: `" output="`"/>
+            <when state="dead: ~" output="~"/>
             <when state="dead: ¨" output="¨"/>
             <when state="dead: ´" output="´"/>
             <when state="dead: ˚" output="˚"/>
         </action>
         <action id="9">
             <when state="none" output="N"/>
+            <when state="dead: ~" output="Ñ"/>
             <when state="dead: ´" output="Ń"/>
         </action>
         <action id="16">
             <when state="none" output="n"/>
+            <when state="dead: ~" output="ñ"/>
             <when state="dead: ´" output="ń"/>
         </action>
         <action id="A">
             <when state="none" output="A"/>
             <when state="dead: ^" output="Â"/>
             <when state="dead: `" output="À"/>
+            <when state="dead: ~" output="Ã"/>
             <when state="dead: ¨" output="Ä"/>
             <when state="dead: ´" output="Á"/>
             <when state="dead: ˚" output="Å"/>
@@ -1076,6 +1080,7 @@
             <when state="none" output="I"/>
             <when state="dead: ^" output="Î"/>
             <when state="dead: `" output="Ì"/>
+            <when state="dead: ~" output="Ĩ"/>
             <when state="dead: ¨" output="Ï"/>
             <when state="dead: ´" output="Í"/>
             <when state="dead: ˚" output="İ"/>
@@ -1100,6 +1105,7 @@
             <when state="none" output="O"/>
             <when state="dead: ^" output="Ô"/>
             <when state="dead: `" output="Ò"/>
+            <when state="dead: ~" output="Õ"/>
             <when state="dead: ¨" output="Ö"/>
             <when state="dead: ´" output="Ó"/>
         </action>
@@ -1120,6 +1126,7 @@
             <when state="none" output="U"/>
             <when state="dead: ^" output="Û"/>
             <when state="dead: `" output="Ù"/>
+            <when state="dead: ~" output="Ũ"/>
             <when state="dead: ¨" output="Ü"/>
             <when state="dead: ´" output="Ú"/>
             <when state="dead: ˚" output="Ů"/>
@@ -1132,6 +1139,7 @@
         <action id="Y">
             <when state="none" output="Y"/>
             <when state="dead: ^" output="Ŷ"/>
+            <when state="dead: ~" output="Ỹ"/>
             <when state="dead: ¨" output="Ÿ"/>
             <when state="dead: ´" output="Ý"/>
         </action>
@@ -1150,6 +1158,7 @@
             <when state="none" output="a"/>
             <when state="dead: ^" output="â"/>
             <when state="dead: `" output="à"/>
+            <when state="dead: ~" output="ã"/>
             <when state="dead: ¨" output="ä"/>
             <when state="dead: ´" output="á"/>
             <when state="dead: ˚" output="å"/>
@@ -1186,6 +1195,7 @@
             <when state="none" output="i"/>
             <when state="dead: ^" output="î"/>
             <when state="dead: `" output="ì"/>
+            <when state="dead: ~" output="ĩ"/>
             <when state="dead: ¨" output="ï"/>
             <when state="dead: ´" output="í"/>
         </action>
@@ -1209,6 +1219,7 @@
             <when state="none" output="o"/>
             <when state="dead: ^" output="ô"/>
             <when state="dead: `" output="ò"/>
+            <when state="dead: ~" output="õ"/>
             <when state="dead: ¨" output="ö"/>
             <when state="dead: ´" output="ó"/>
         </action>
@@ -1229,6 +1240,7 @@
             <when state="none" output="u"/>
             <when state="dead: ^" output="û"/>
             <when state="dead: `" output="ù"/>
+            <when state="dead: ~" output="ũ"/>
             <when state="dead: ¨" output="ü"/>
             <when state="dead: ´" output="ú"/>
             <when state="dead: ˚" output="ů"/>
@@ -1242,6 +1254,7 @@
         <action id="y">
             <when state="none" output="y"/>
             <when state="dead: ^" output="ŷ"/>
+            <when state="dead: ~" output="ỹ"/>
             <when state="dead: ¨" output="ÿ"/>
             <when state="dead: ´" output="ý"/>
             <when state="dead: ˚" output="ẙ"/>

--- a/EurKEY.keylayout
+++ b/EurKEY.keylayout
@@ -45,16 +45,16 @@
             <key code="0" action="a"/>
             <key code="1" action="s"/>
             <key code="2" action="d"/>
-            <key code="3" output="f"/>
+            <key code="3" action="f"/>
             <key code="4" action="h"/>
             <key code="5" action="g"/>
             <key code="6" action="z"/>
-            <key code="7" output="x"/>
+            <key code="7" action="x"/>
             <key code="8" action="c"/>
-            <key code="9" output="v"/>
+            <key code="9" action="v"/>
             <key code="10" output="§"/>
             <key code="11" action="b"/>
-            <key code="12" output="q"/>
+            <key code="12" action="q"/>
             <key code="13" action="w"/>
             <key code="14" action="e"/>
             <key code="15" action="r"/>
@@ -64,30 +64,30 @@
             <key code="19" action="2"/>
             <key code="20" action="3"/>
             <key code="21" action="4"/>
-            <key code="22" output="6"/>
+            <key code="22" action="6"/>
             <key code="23" action="5"/>
             <key code="24" action="="/>
-            <key code="25" output="9"/>
-            <key code="26" output="7"/>
-            <key code="27" output="-"/>
-            <key code="28" output="8"/>
-            <key code="29" output="0"/>
-            <key code="30" output="]"/>
+            <key code="25" action="9"/>
+            <key code="26" action="7"/>
+            <key code="27" action="-"/>
+            <key code="28" action="8"/>
+            <key code="29" action="0"/>
+            <key code="30" action="]"/>
             <key code="31" action="o"/>
             <key code="32" action="u"/>
-            <key code="33" output="["/>
+            <key code="33" action="["/>
             <key code="34" action="i"/>
             <key code="35" action="p"/>
             <key code="36" output="&#x000D;"/>
             <key code="37" action="l"/>
             <key code="38" action="j"/>
-            <key code="39" output="&#x0027;"/>
+            <key code="39" action="&#x0027;"/>
             <key code="40" action="k"/>
-            <key code="41" output=";"/>
+            <key code="41" action=";"/>
             <key code="42" output="\"/>
             <key code="43" output=","/>
             <key code="44" output="/"/>
-            <key code="45" action="16"/>
+            <key code="45" action="n"/>
             <key code="46" action="m"/>
             <key code="47" output="."/>
             <key code="48" output="&#x0009;"/>
@@ -157,49 +157,49 @@
             <key code="0" action="A"/>
             <key code="1" action="S"/>
             <key code="2" action="D"/>
-            <key code="3" output="F"/>
+            <key code="3" action="F"/>
             <key code="4" action="H"/>
             <key code="5" action="G"/>
             <key code="6" action="Z"/>
-            <key code="7" output="X"/>
+            <key code="7" action="X"/>
             <key code="8" action="C"/>
-            <key code="9" output="V"/>
+            <key code="9" action="V"/>
             <key code="10" output="±"/>
             <key code="11" action="B"/>
-            <key code="12" output="Q"/>
+            <key code="12" action="Q"/>
             <key code="13" action="W"/>
             <key code="14" action="E"/>
             <key code="15" action="R"/>
             <key code="16" action="Y"/>
             <key code="17" action="T"/>
-            <key code="18" output="!"/>
-            <key code="19" output="@"/>
-            <key code="20" output="#"/>
-            <key code="21" output="$"/>
-            <key code="22" output="^"/>
-            <key code="23" output="%"/>
+            <key code="18" action="!"/>
+            <key code="19" action="@"/>
+            <key code="20" action="#"/>
+            <key code="21" action="$"/>
+            <key code="22" action="^"/>
+            <key code="23" action="%"/>
             <key code="24" action="+"/>
-            <key code="25" output="("/>
-            <key code="26" output="&#x0026;"/>
-            <key code="27" output="_"/>
-            <key code="28" output="*"/>
-            <key code="29" output=")"/>
-            <key code="30" output="}"/>
+            <key code="25" action="("/>
+            <key code="26" action="&#x0026;"/>
+            <key code="27" action="_"/>
+            <key code="28" action="*"/>
+            <key code="29" action=")"/>
+            <key code="30" action="}"/>
             <key code="31" action="O"/>
             <key code="32" action="U"/>
-            <key code="33" output="{"/>
+            <key code="33" action="{"/>
             <key code="34" action="I"/>
             <key code="35" action="P"/>
             <key code="36" output="&#x000D;"/>
             <key code="37" action="L"/>
             <key code="38" action="J"/>
-            <key code="39" output="&#x0022;"/>
+            <key code="39" action="&#x0022;"/>
             <key code="40" action="K"/>
             <key code="41" output=":"/>
             <key code="42" output="|"/>
             <key code="43" output="&#x003C;"/>
             <key code="44" output="?"/>
-            <key code="45" action="9"/>
+            <key code="45" action="N"/>
             <key code="46" action="M"/>
             <key code="47" output="&#x003E;"/>
             <key code="48" output="&#x0009;"/>
@@ -269,16 +269,16 @@
             <key code="0" action="A"/>
             <key code="1" action="S"/>
             <key code="2" action="D"/>
-            <key code="3" output="F"/>
+            <key code="3" action="F"/>
             <key code="4" action="H"/>
             <key code="5" action="G"/>
             <key code="6" action="Z"/>
-            <key code="7" output="X"/>
+            <key code="7" action="X"/>
             <key code="8" action="C"/>
-            <key code="9" output="V"/>
+            <key code="9" action="V"/>
             <key code="10" output="§"/>
             <key code="11" action="B"/>
-            <key code="12" output="Q"/>
+            <key code="12" action="Q"/>
             <key code="13" action="W"/>
             <key code="14" action="E"/>
             <key code="15" action="R"/>
@@ -288,14 +288,14 @@
             <key code="19" action="2"/>
             <key code="20" action="3"/>
             <key code="21" action="4"/>
-            <key code="22" output="6"/>
+            <key code="22" action="6"/>
             <key code="23" action="5"/>
             <key code="24" action="="/>
-            <key code="25" output="9"/>
-            <key code="26" output="7"/>
+            <key code="25" action="9"/>
+            <key code="26" action="7"/>
             <key code="27" output="-"/>
-            <key code="28" output="8"/>
-            <key code="29" output="0"/>
+            <key code="28" action="8"/>
+            <key code="29" action="0"/>
             <key code="30" output="]"/>
             <key code="31" action="O"/>
             <key code="32" action="U"/>
@@ -311,7 +311,7 @@
             <key code="42" output="\"/>
             <key code="43" output=","/>
             <key code="44" output="/"/>
-            <key code="45" action="9"/>
+            <key code="45" action="N"/>
             <key code="46" action="M"/>
             <key code="47" output="."/>
             <key code="48" output="&#x0009;"/>
@@ -400,7 +400,7 @@
             <key code="19" output="ª"/>
             <key code="20" output="º"/>
             <key code="21" output="£"/>
-            <key code="22" action="^"/>
+            <key code="22" action="6 option"/>
             <key code="23" output="€"/>
             <key code="24" output="×"/>
             <key code="25" output="“"/>
@@ -1020,50 +1020,122 @@
         </keyMap>
     </keyMapSet>
     <actions>
+        <action id="!">
+            <when state="none" output="!"/>
+            <when state="dead: Ω" output="₁"/>
+        </action>
+        <action id="#">
+            <when state="none" output="#"/>
+            <when state="dead: Ω" output="₃"/>
+        </action>
+        <action id="$">
+            <when state="none" output="$"/>
+            <when state="dead: Ω" output="₄"/>
+        </action>
+        <action id="%">
+            <when state="none" output="%"/>
+            <when state="dead: Ω" output="₅"/>
+        </action>
+        <action id="&#x0022;">
+            <when state="none" output="&#x0022;"/>
+            <when state="dead: Ω" output="₊"/>
+        </action>
+        <action id="&#x0026;">
+            <when state="none" output="&#x0026;"/>
+            <when state="dead: Ω" output="₇"/>
+        </action>
+        <action id="&#x0027;">
+            <when state="none" output="&#x0027;"/>
+            <when state="dead: Ω" output="₌"/>
+        </action>
+        <action id="(">
+            <when state="none" output="("/>
+            <when state="dead: Ω" output="₉"/>
+        </action>
+        <action id=")">
+            <when state="none" output=")"/>
+            <when state="dead: Ω" output="₀"/>
+        </action>
+        <action id="*">
+            <when state="none" output="*"/>
+            <when state="dead: Ω" output="₈"/>
+        </action>
         <action id="+">
             <when state="none" output="+"/>
             <when state="dead: ©" output="⇔"/>
+            <when state="dead: Ω" output="⁺"/>
+        </action>
+        <action id="-">
+            <when state="none" output="-"/>
+            <when state="dead: Ω" output="⁻"/>
+        </action>
+        <action id="0">
+            <when state="none" output="0"/>
+            <when state="dead: Ω" output="⁰"/>
         </action>
         <action id="1">
             <when state="none" output="1"/>
             <when state="dead: ©" output="¼"/>
             <when state="dead: ¯" output="‐"/>
+            <when state="dead: Ω" output="¹"/>
         </action>
         <action id="2">
             <when state="none" output="2"/>
             <when state="dead: ©" output="½"/>
             <when state="dead: ¯" output="–"/>
+            <when state="dead: Ω" output="²"/>
         </action>
         <action id="3">
             <when state="none" output="3"/>
             <when state="dead: ©" output="¾"/>
             <when state="dead: ¯" output="—"/>
+            <when state="dead: Ω" output="³"/>
         </action>
         <action id="4">
             <when state="none" output="4"/>
             <when state="dead: ©" output="⅓"/>
+            <when state="dead: Ω" output="⁴"/>
         </action>
         <action id="5">
             <when state="none" output="5"/>
             <when state="dead: ©" output="⅔"/>
+            <when state="dead: ¯" output="¯"/>
+            <when state="dead: ´" output="´"/>
+            <when state="dead: ˇ" output="ˇ"/>
+            <when state="dead: ˚" output="˚"/>
+            <when state="dead: Ω" output="⁵"/>
+        </action>
+        <action id="6">
+            <when state="none" output="6"/>
+            <when state="dead: Ω" output="⁶"/>
+        </action>
+        <action id="6 option">
+            <when state="none" next="dead: ^"/>
+        </action>
+        <action id="7">
+            <when state="none" output="7"/>
+            <when state="dead: Ω" output="⁷"/>
+        </action>
+        <action id="8">
+            <when state="none" output="8"/>
+            <when state="dead: Ω" output="⁸"/>
         </action>
         <action id="9">
-            <when state="none" output="N"/>
-            <when state="dead: ~" output="Ñ"/>
-            <when state="dead: ©" output="⇙"/>
-            <when state="dead: ´" output="Ń"/>
-            <when state="dead: ˇ" output="Ň"/>
+            <when state="none" output="9"/>
+            <when state="dead: Ω" output="⁹"/>
         </action>
-        <action id="16">
-            <when state="none" output="n"/>
-            <when state="dead: ~" output="ñ"/>
-            <when state="dead: ©" output="↙"/>
-            <when state="dead: ´" output="ń"/>
-            <when state="dead: ˇ" output="ň"/>
+        <action id=";">
+            <when state="none" output=";"/>
+            <when state="dead: Ω" output="₋"/>
         </action>
         <action id="=">
             <when state="none" output="="/>
             <when state="dead: ©" output="↔"/>
+            <when state="dead: Ω" output="⁼"/>
+        </action>
+        <action id="@">
+            <when state="none" output="@"/>
+            <when state="dead: Ω" output="₂"/>
         </action>
         <action id="A">
             <when state="none" output="A"/>
@@ -1075,10 +1147,12 @@
             <when state="dead: ¯" output="Ā"/>
             <when state="dead: ˇ" output="Ǎ"/>
             <when state="dead: ˚" output="Å"/>
+            <when state="dead: Ω" output="Α"/>
         </action>
         <action id="B">
             <when state="none" output="B"/>
             <when state="dead: ´" output="Ɓ"/>
+            <when state="dead: Ω" output="Β"/>
         </action>
         <action id="C">
             <when state="none" output="C"/>
@@ -1087,11 +1161,13 @@
             <when state="dead: ´" output="Ć"/>
             <when state="dead: ˇ" output="Č"/>
             <when state="dead: ˚" output="Ċ"/>
+            <when state="dead: Ω" output="Χ"/>
         </action>
         <action id="D">
             <when state="none" output="D"/>
             <when state="dead: ¯" output="Đ"/>
             <when state="dead: ˇ" output="Ď"/>
+            <when state="dead: Ω" output="Δ"/>
         </action>
         <action id="E">
             <when state="none" output="E"/>
@@ -1102,6 +1178,11 @@
             <when state="dead: ´" output="É"/>
             <when state="dead: ˇ" output="Ě"/>
             <when state="dead: ˚" output="Ė"/>
+            <when state="dead: Ω" output="Ε"/>
+        </action>
+        <action id="F">
+            <when state="none" output="F"/>
+            <when state="dead: Ω" output="Φ"/>
         </action>
         <action id="G">
             <when state="none" output="G"/>
@@ -1110,6 +1191,7 @@
             <when state="dead: ´" output="Ǵ"/>
             <when state="dead: ˇ" output="Ǧ"/>
             <when state="dead: ˚" output="Ġ"/>
+            <when state="dead: Ω" output="Γ"/>
         </action>
         <action id="H">
             <when state="none" output="H"/>
@@ -1117,6 +1199,7 @@
             <when state="dead: ©" output="⇐"/>
             <when state="dead: ¯" output="Ħ"/>
             <when state="dead: ˇ" output="Ȟ"/>
+            <when state="dead: Ω" output="Θ"/>
         </action>
         <action id="I">
             <when state="none" output="I"/>
@@ -1129,17 +1212,20 @@
             <when state="dead: ´" output="Í"/>
             <when state="dead: ˇ" output="Ǐ"/>
             <when state="dead: ˚" output="İ"/>
+            <when state="dead: Ω" output="Η"/>
         </action>
         <action id="J">
             <when state="none" output="J"/>
             <when state="dead: ^" output="Ĵ"/>
             <when state="dead: ©" output="⇓"/>
+            <when state="dead: Ω" output="Ι"/>
         </action>
         <action id="K">
             <when state="none" output="K"/>
             <when state="dead: ©" output="⇑"/>
             <when state="dead: ´" output="Ḱ"/>
             <when state="dead: ˇ" output="Ǩ"/>
+            <when state="dead: Ω" output="Κ"/>
         </action>
         <action id="L">
             <when state="none" output="L"/>
@@ -1147,11 +1233,21 @@
             <when state="dead: ¯" output="Ḻ"/>
             <when state="dead: ´" output="Ł"/>
             <when state="dead: ˇ" output="Ľ"/>
+            <when state="dead: Ω" output="Λ"/>
         </action>
         <action id="M">
             <when state="none" output="M"/>
             <when state="dead: ©" output="⇘"/>
             <when state="dead: ´" output="Ḿ"/>
+            <when state="dead: Ω" output="Μ"/>
+        </action>
+        <action id="N">
+            <when state="none" output="N"/>
+            <when state="dead: ~" output="Ñ"/>
+            <when state="dead: ©" output="⇙"/>
+            <when state="dead: ´" output="Ń"/>
+            <when state="dead: ˇ" output="Ň"/>
+            <when state="dead: Ω" output="Ν"/>
         </action>
         <action id="O">
             <when state="none" output="O"/>
@@ -1162,17 +1258,24 @@
             <when state="dead: ¯" output="Ō"/>
             <when state="dead: ´" output="Ó"/>
             <when state="dead: ˇ" output="Ǒ"/>
+            <when state="dead: Ω" output="Ο"/>
         </action>
         <action id="P">
             <when state="none" output="P"/>
             <when state="dead: ©" output="℗"/>
             <when state="dead: ´" output="Ṕ"/>
+            <when state="dead: Ω" output="Π"/>
+        </action>
+        <action id="Q">
+            <when state="none" output="Q"/>
+            <when state="dead: Ω" output="Ω"/>
         </action>
         <action id="R">
             <when state="none" output="R"/>
             <when state="dead: ©" output="®"/>
             <when state="dead: ´" output="Ŕ"/>
             <when state="dead: ˇ" output="Ř"/>
+            <when state="dead: Ω" output="Ρ"/>
         </action>
         <action id="S">
             <when state="none" output="S"/>
@@ -1180,12 +1283,14 @@
             <when state="dead: ©" output="℠"/>
             <when state="dead: ´" output="Ś"/>
             <when state="dead: ˇ" output="Š"/>
+            <when state="dead: Ω" output="Σ"/>
         </action>
         <action id="T">
             <when state="none" output="T"/>
             <when state="dead: ©" output="™"/>
             <when state="dead: ¯" output="Ŧ"/>
             <when state="dead: ˇ" output="Ť"/>
+            <when state="dead: Ω" output="Τ"/>
         </action>
         <action id="U">
             <when state="none" output="U"/>
@@ -1198,11 +1303,21 @@
             <when state="dead: ´" output="Ú"/>
             <when state="dead: ˇ" output="Ǔ"/>
             <when state="dead: ˚" output="Ů"/>
+            <when state="dead: Ω" output="Ω"/>
+        </action>
+        <action id="V">
+            <when state="none" output="V"/>
+            <when state="dead: Ω" output="Β"/>
         </action>
         <action id="W">
             <when state="none" output="W"/>
             <when state="dead: ^" output="Ŵ"/>
             <when state="dead: ´" output="Ẃ"/>
+            <when state="dead: Ω" output="Ψ"/>
+        </action>
+        <action id="X">
+            <when state="none" output="X"/>
+            <when state="dead: Ω" output="Ξ"/>
         </action>
         <action id="Y">
             <when state="none" output="Y"/>
@@ -1211,15 +1326,29 @@
             <when state="dead: ¨" output="Ÿ"/>
             <when state="dead: ¯" output="Ȳ"/>
             <when state="dead: ´" output="Ý"/>
+            <when state="dead: Ω" output="Υ"/>
         </action>
         <action id="Z">
             <when state="none" output="Z"/>
             <when state="dead: ´" output="Ź"/>
             <when state="dead: ˇ" output="Ž"/>
             <when state="dead: ˚" output="Ż"/>
+            <when state="dead: Ω" output="Ζ"/>
+        </action>
+        <action id="[">
+            <when state="none" output="["/>
+            <when state="dead: Ω" output="⁽"/>
+        </action>
+        <action id="]">
+            <when state="none" output="]"/>
+            <when state="dead: Ω" output="⁾"/>
         </action>
         <action id="^">
-            <when state="none" next="dead: ^"/>
+            <when state="none" output="^"/>
+            <when state="dead: Ω" output="₆"/>
+        </action>
+        <action id="_">
+            <when state="none" output="_"/>
         </action>
         <action id="`">
             <when state="none" next="dead: `"/>
@@ -1234,10 +1363,12 @@
             <when state="dead: ¯" output="ā"/>
             <when state="dead: ˇ" output="ǎ"/>
             <when state="dead: ˚" output="å"/>
+            <when state="dead: Ω" output="α"/>
         </action>
         <action id="b">
             <when state="none" output="b"/>
             <when state="dead: ´" output="ɓ"/>
+            <when state="dead: Ω" output="β"/>
         </action>
         <action id="c">
             <when state="none" output="c"/>
@@ -1246,11 +1377,13 @@
             <when state="dead: ´" output="ć"/>
             <when state="dead: ˇ" output="č"/>
             <when state="dead: ˚" output="ċ"/>
+            <when state="dead: Ω" output="χ"/>
         </action>
         <action id="d">
             <when state="none" output="d"/>
             <when state="dead: ¯" output="đ"/>
             <when state="dead: ˇ" output="ď"/>
+            <when state="dead: Ω" output="δ"/>
         </action>
         <action id="e">
             <when state="none" output="e"/>
@@ -1261,6 +1394,11 @@
             <when state="dead: ´" output="é"/>
             <when state="dead: ˇ" output="ě"/>
             <when state="dead: ˚" output="ė"/>
+            <when state="dead: Ω" output="ε"/>
+        </action>
+        <action id="f">
+            <when state="none" output="f"/>
+            <when state="dead: Ω" output="φ"/>
         </action>
         <action id="g">
             <when state="none" output="g"/>
@@ -1269,6 +1407,7 @@
             <when state="dead: ´" output="ǵ"/>
             <when state="dead: ˇ" output="ǧ"/>
             <when state="dead: ˚" output="ġ"/>
+            <when state="dead: Ω" output="γ"/>
         </action>
         <action id="h">
             <when state="none" output="h"/>
@@ -1276,6 +1415,7 @@
             <when state="dead: ©" output="←"/>
             <when state="dead: ¯" output="ħ"/>
             <when state="dead: ˇ" output="ȟ"/>
+            <when state="dead: Ω" output="θ"/>
         </action>
         <action id="i">
             <when state="none" output="i"/>
@@ -1287,18 +1427,21 @@
             <when state="dead: ¯" output="ī"/>
             <when state="dead: ´" output="í"/>
             <when state="dead: ˇ" output="ǐ"/>
+            <when state="dead: Ω" output="η"/>
         </action>
         <action id="j">
             <when state="none" output="j"/>
             <when state="dead: ^" output="ĵ"/>
             <when state="dead: ©" output="↓"/>
             <when state="dead: ˇ" output="ǰ"/>
+            <when state="dead: Ω" output="ι"/>
         </action>
         <action id="k">
             <when state="none" output="k"/>
             <when state="dead: ©" output="↑"/>
             <when state="dead: ´" output="ḱ"/>
             <when state="dead: ˇ" output="ǩ"/>
+            <when state="dead: Ω" output="κ"/>
         </action>
         <action id="l">
             <when state="none" output="l"/>
@@ -1306,11 +1449,21 @@
             <when state="dead: ¯" output="ḻ"/>
             <when state="dead: ´" output="ł"/>
             <when state="dead: ˇ" output="ľ"/>
+            <when state="dead: Ω" output="λ"/>
         </action>
         <action id="m">
             <when state="none" output="m"/>
             <when state="dead: ©" output="↘"/>
             <when state="dead: ´" output="ḿ"/>
+            <when state="dead: Ω" output="μ"/>
+        </action>
+        <action id="n">
+            <when state="none" output="n"/>
+            <when state="dead: ~" output="ñ"/>
+            <when state="dead: ©" output="↙"/>
+            <when state="dead: ´" output="ń"/>
+            <when state="dead: ˇ" output="ň"/>
+            <when state="dead: Ω" output="ν"/>
         </action>
         <action id="o">
             <when state="none" output="o"/>
@@ -1321,17 +1474,24 @@
             <when state="dead: ¯" output="ō"/>
             <when state="dead: ´" output="ó"/>
             <when state="dead: ˇ" output="ǒ"/>
+            <when state="dead: Ω" output="ο"/>
         </action>
         <action id="p">
             <when state="none" output="p"/>
             <when state="dead: ©" output="℗"/>
             <when state="dead: ´" output="ṕ"/>
+            <when state="dead: Ω" output="π"/>
+        </action>
+        <action id="q">
+            <when state="none" output="q"/>
+            <when state="dead: Ω" output="ω"/>
         </action>
         <action id="r">
             <when state="none" output="r"/>
             <when state="dead: ©" output="®"/>
             <when state="dead: ´" output="ŕ"/>
             <when state="dead: ˇ" output="ř"/>
+            <when state="dead: Ω" output="ρ"/>
         </action>
         <action id="s">
             <when state="none" output="s"/>
@@ -1339,6 +1499,7 @@
             <when state="dead: ©" output="℠"/>
             <when state="dead: ´" output="ś"/>
             <when state="dead: ˇ" output="š"/>
+            <when state="dead: Ω" output="σ"/>
         </action>
         <action id="space">
             <when state="none" output=" "/>
@@ -1357,6 +1518,7 @@
             <when state="dead: ©" output="™"/>
             <when state="dead: ¯" output="ŧ"/>
             <when state="dead: ˇ" output="ť"/>
+            <when state="dead: Ω" output="τ"/>
         </action>
         <action id="u">
             <when state="none" output="u"/>
@@ -1369,12 +1531,22 @@
             <when state="dead: ´" output="ú"/>
             <when state="dead: ˇ" output="ǔ"/>
             <when state="dead: ˚" output="ů"/>
+            <when state="dead: Ω" output="ω"/>
+        </action>
+        <action id="v">
+            <when state="none" output="v"/>
+            <when state="dead: Ω" output="β"/>
         </action>
         <action id="w">
             <when state="none" output="w"/>
             <when state="dead: ^" output="ŵ"/>
             <when state="dead: ´" output="ẃ"/>
             <when state="dead: ˚" output="ẘ"/>
+            <when state="dead: Ω" output="ψ"/>
+        </action>
+        <action id="x">
+            <when state="none" output="x"/>
+            <when state="dead: Ω" output="ξ"/>
         </action>
         <action id="y">
             <when state="none" output="y"/>
@@ -1384,12 +1556,22 @@
             <when state="dead: ¯" output="ȳ"/>
             <when state="dead: ´" output="ý"/>
             <when state="dead: ˚" output="ẙ"/>
+            <when state="dead: Ω" output="υ"/>
         </action>
         <action id="z">
             <when state="none" output="z"/>
             <when state="dead: ´" output="ź"/>
             <when state="dead: ˇ" output="ž"/>
             <when state="dead: ˚" output="ż"/>
+            <when state="dead: Ω" output="ζ"/>
+        </action>
+        <action id="{">
+            <when state="none" output="{"/>
+            <when state="dead: Ω" output="₍"/>
+        </action>
+        <action id="}">
+            <when state="none" output="}"/>
+            <when state="dead: Ω" output="₎"/>
         </action>
         <action id="~">
             <when state="none" next="dead: ~"/>

--- a/EurKEY.keylayout
+++ b/EurKEY.keylayout
@@ -378,62 +378,62 @@
             <key code="126" output="&#x001E;"/>
         </keyMap>
         <keyMap index="3">
-            <key code="0" output="å"/>
+            <key code="0" output="ä"/>
             <key code="1" output="ß"/>
-            <key code="2" output="∂"/>
-            <key code="3" output="ƒ"/>
-            <key code="4" output="˙"/>
-            <key code="5" output="©"/>
-            <key code="6" output="Ω"/>
-            <key code="7" output="≈"/>
+            <key code="2" output="ð"/>
+            <key code="3" output="è"/>
+            <key code="4" output="ù"/>
+            <key code="5" output="é"/>
+            <key code="6" output="à"/>
+            <key code="7" output="á"/>
             <key code="8" output="ç"/>
-            <key code="9" output="√"/>
+            <key code="9" output="ì"/>
             <key code="10" output="§"/>
-            <key code="11" output="∫"/>
-            <key code="12" output="œ"/>
-            <key code="13" output="∑"/>
-            <key code="14" action="0"/>
-            <key code="15" output="®"/>
-            <key code="16" output="¥"/>
-            <key code="17" output="†"/>
+            <key code="11" output="í"/>
+            <key code="12" output="æ"/>
+            <key code="13" output="å"/>
+            <key code="14" output="ë"/>
+            <key code="15" output="ý"/>
+            <key code="16" output="ÿ"/>
+            <key code="17" output="þ"/>
             <key code="18" output="¡"/>
-            <key code="19" output="™"/>
-            <key code="20" output="£"/>
-            <key code="21" output="¢"/>
-            <key code="22" output="§"/>
-            <key code="23" output="∞"/>
-            <key code="24" output="≠"/>
-            <key code="25" output="ª"/>
-            <key code="26" output="¶"/>
-            <key code="27" output="–"/>
-            <key code="28" output="•"/>
-            <key code="29" output="º"/>
-            <key code="30" output="‘"/>
-            <key code="31" output="ø"/>
-            <key code="32" action="3"/>
-            <key code="33" output="“"/>
-            <key code="34" action="2"/>
-            <key code="35" output="π"/>
+            <key code="19" output="ª"/>
+            <key code="20" output="º"/>
+            <key code="21" output="£"/>
+            <key code="22" action="^"/>
+            <key code="23" output="€"/>
+            <key code="24" output="×"/>
+            <key code="25" output="“"/>
+            <key code="26" action="˚"/>
+            <key code="27" action="©"/>
+            <key code="28" output="„"/>
+            <key code="29" output="”"/>
+            <key code="30" output="»"/>
+            <key code="31" output="ö"/>
+            <key code="32" output="ü"/>
+            <key code="33" output="«"/>
+            <key code="34" output="ï"/>
+            <key code="35" output="œ"/>
             <key code="36" output="&#x000D;"/>
-            <key code="37" output="¬"/>
-            <key code="38" output="∆"/>
-            <key code="39" output="æ"/>
-            <key code="40" output="˚"/>
-            <key code="41" output="…"/>
-            <key code="42" output="«"/>
-            <key code="43" output="≤"/>
-            <key code="44" output="÷"/>
-            <key code="45" action="4"/>
-            <key code="46" output="µ"/>
-            <key code="47" output="≥"/>
+            <key code="37" output="ø"/>
+            <key code="38" output="ú"/>
+            <key code="39" action="´"/>
+            <key code="40" output="ĳ"/>
+            <key code="41" action="¨"/>
+            <key code="42" output="¬"/>
+            <key code="43" output="ò"/>
+            <key code="44" output="¿"/>
+            <key code="45" output="ñ"/>
+            <key code="46" action="Ω"/>
+            <key code="47" output="ó"/>
             <key code="48" output="&#x0009;"/>
             <key code="49" output=" "/>
-            <key code="50" action="1"/>
+            <key code="50" action="`"/>
             <key code="51" output="&#x0008;"/>
             <key code="52" output="&#x0003;"/>
             <key code="53" output="&#x001B;"/>
             <key code="64" output="&#x0010;"/>
-            <key code="65" output="."/>
+            <key code="65" output=","/>
             <key code="66" output="&#x001D;"/>
             <key code="67" output="*"/>
             <key code="69" output="+"/>
@@ -1020,125 +1020,95 @@
         </keyMap>
     </keyMapSet>
     <actions>
-        <action id="0">
-            <when state="none" next="s1"/>
-        </action>
         <action id="1">
             <when state="none" next="s2"/>
         </action>
-        <action id="2">
-            <when state="none" next="s3"/>
-        </action>
-        <action id="3">
-            <when state="none" next="s4"/>
-        </action>
-        <action id="4">
-            <when state="none" next="s5"/>
-        </action>
         <action id="5">
             <when state="none" output=" "/>
-            <when state="s1" output="´"/>
             <when state="s2" output="`"/>
-            <when state="s3" output="ˆ"/>
-            <when state="s4" output="¨"/>
-            <when state="s5" output="˜"/>
         </action>
         <action id="6">
             <when state="none" output="A"/>
-            <when state="s1" output="Á"/>
             <when state="s2" output="À"/>
-            <when state="s3" output="Â"/>
-            <when state="s4" output="Ä"/>
-            <when state="s5" output="Ã"/>
         </action>
         <action id="7">
             <when state="none" output="E"/>
-            <when state="s1" output="É"/>
             <when state="s2" output="È"/>
-            <when state="s3" output="Ê"/>
-            <when state="s4" output="Ë"/>
         </action>
         <action id="8">
             <when state="none" output="I"/>
-            <when state="s1" output="Í"/>
             <when state="s2" output="Ì"/>
-            <when state="s3" output="Î"/>
-            <when state="s4" output="Ï"/>
         </action>
         <action id="9">
             <when state="none" output="N"/>
-            <when state="s5" output="Ñ"/>
         </action>
         <action id="10">
             <when state="none" output="O"/>
-            <when state="s1" output="Ó"/>
             <when state="s2" output="Ò"/>
-            <when state="s3" output="Ô"/>
-            <when state="s4" output="Ö"/>
-            <when state="s5" output="Õ"/>
         </action>
         <action id="11">
             <when state="none" output="U"/>
-            <when state="s1" output="Ú"/>
             <when state="s2" output="Ù"/>
-            <when state="s3" output="Û"/>
-            <when state="s4" output="Ü"/>
         </action>
         <action id="12">
             <when state="none" output="Y"/>
-            <when state="s4" output="Ÿ"/>
         </action>
         <action id="13">
             <when state="none" output="a"/>
-            <when state="s1" output="á"/>
             <when state="s2" output="à"/>
-            <when state="s3" output="â"/>
-            <when state="s4" output="ä"/>
-            <when state="s5" output="ã"/>
         </action>
         <action id="14">
             <when state="none" output="e"/>
-            <when state="s1" output="é"/>
             <when state="s2" output="è"/>
-            <when state="s3" output="ê"/>
-            <when state="s4" output="ë"/>
         </action>
         <action id="15">
             <when state="none" output="i"/>
-            <when state="s1" output="í"/>
             <when state="s2" output="ì"/>
-            <when state="s3" output="î"/>
-            <when state="s4" output="ï"/>
         </action>
         <action id="16">
             <when state="none" output="n"/>
-            <when state="s5" output="ñ"/>
         </action>
         <action id="17">
             <when state="none" output="o"/>
-            <when state="s1" output="ó"/>
             <when state="s2" output="ò"/>
-            <when state="s3" output="ô"/>
-            <when state="s4" output="ö"/>
-            <when state="s5" output="õ"/>
         </action>
         <action id="18">
             <when state="none" output="u"/>
-            <when state="s1" output="ú"/>
             <when state="s2" output="ù"/>
-            <when state="s3" output="û"/>
-            <when state="s4" output="ü"/>
         </action>
         <action id="19">
             <when state="none" output="y"/>
-            <when state="s4" output="ÿ"/>
+        </action>
+        <action id="^">
+            <when state="none" next="dead: ^"/>
+        </action>
+        <action id="`">
+            <when state="none" next="dead: `"/>
+        </action>
+        <action id="¨">
+            <when state="none" next="dead: ¨"/>
+        </action>
+        <action id="©">
+            <when state="none" next="dead: ©"/>
+        </action>
+        <action id="´">
+            <when state="none" next="dead: ´"/>
+        </action>
+        <action id="˚">
+            <when state="none" next="dead: ˚"/>
+        </action>
+        <action id="Ω">
+            <when state="none" next="dead: Ω"/>
         </action>
     </actions>
     <terminators>
-        <when state="s1" output="´"/>
+        <when state="dead: ^" output="^"/>
+        <when state="dead: `" output="`"/>
+        <when state="dead: ¨" output="¨"/>
+        <when state="dead: ©" output="©"/>
+        <when state="dead: ´" output="´"/>
+        <when state="dead: ˚" output="˚"/>
+        <when state="dead: Ω" output="Ω"/>
         <when state="s2" output="`"/>
-        <when state="s3" output="ˆ"/>
-        <when state="s4" output="¨"/>
-        <when state="s5" output="˜"/>
     </terminators>
 </keyboard>

--- a/EurKEY.keylayout
+++ b/EurKEY.keylayout
@@ -60,9 +60,9 @@
             <key code="15" action="r"/>
             <key code="16" action="y"/>
             <key code="17" action="t"/>
-            <key code="18" output="1"/>
-            <key code="19" output="2"/>
-            <key code="20" output="3"/>
+            <key code="18" action="1"/>
+            <key code="19" action="2"/>
+            <key code="20" action="3"/>
             <key code="21" output="4"/>
             <key code="22" output="6"/>
             <key code="23" output="5"/>
@@ -1020,12 +1020,25 @@
         </keyMap>
     </keyMapSet>
     <actions>
+        <action id="1">
+            <when state="none" output="1"/>
+            <when state="dead: ¯" output="‐"/>
+        </action>
+        <action id="2">
+            <when state="none" output="2"/>
+            <when state="dead: ¯" output="–"/>
+        </action>
+        <action id="3">
+            <when state="none" output="3"/>
+            <when state="dead: ¯" output="—"/>
+        </action>
         <action id="5">
             <when state="none" output=" "/>
             <when state="dead: ^" output="^"/>
             <when state="dead: `" output="`"/>
             <when state="dead: ~" output="~"/>
             <when state="dead: ¨" output="¨"/>
+            <when state="dead: ¯" output="¯"/>
             <when state="dead: ´" output="´"/>
             <when state="dead: ˇ" output="ˇ"/>
             <when state="dead: ˚" output="˚"/>
@@ -1049,6 +1062,7 @@
             <when state="dead: ~" output="Ã"/>
             <when state="dead: ¨" output="Ä"/>
             <when state="dead: ´" output="Á"/>
+            <when state="dead: ¯" output="Ā"/>
             <when state="dead: ˇ" output="Ǎ"/>
             <when state="dead: ˚" output="Å"/>
         </action>
@@ -1065,6 +1079,7 @@
         </action>
         <action id="D">
             <when state="none" output="D"/>
+            <when state="dead: ¯" output="Đ"/>
             <when state="dead: ˇ" output="Ď"/>
         </action>
         <action id="E">
@@ -1072,6 +1087,7 @@
             <when state="dead: ^" output="Ê"/>
             <when state="dead: `" output="È"/>
             <when state="dead: ¨" output="Ë"/>
+            <when state="dead: ¯" output="Ē"/>
             <when state="dead: ´" output="É"/>
             <when state="dead: ˇ" output="Ě"/>
             <when state="dead: ˚" output="Ė"/>
@@ -1079,6 +1095,7 @@
         <action id="G">
             <when state="none" output="G"/>
             <when state="dead: ^" output="Ĝ"/>
+            <when state="dead: ¯" output="Ḡ"/>
             <when state="dead: ´" output="Ǵ"/>
             <when state="dead: ˇ" output="Ǧ"/>
             <when state="dead: ˚" output="Ġ"/>
@@ -1086,6 +1103,7 @@
         <action id="H">
             <when state="none" output="H"/>
             <when state="dead: ^" output="Ĥ"/>
+            <when state="dead: ¯" output="Ħ"/>
             <when state="dead: ˇ" output="Ȟ"/>
         </action>
         <action id="I">
@@ -1094,6 +1112,7 @@
             <when state="dead: `" output="Ì"/>
             <when state="dead: ~" output="Ĩ"/>
             <when state="dead: ¨" output="Ï"/>
+            <when state="dead: ¯" output="Ī"/>
             <when state="dead: ´" output="Í"/>
             <when state="dead: ˇ" output="Ǐ"/>
             <when state="dead: ˚" output="İ"/>
@@ -1109,6 +1128,7 @@
         </action>
         <action id="L">
             <when state="none" output="L"/>
+            <when state="dead: ¯" output="Ḻ"/>
             <when state="dead: ´" output="Ł"/>
             <when state="dead: ˇ" output="Ľ"/>
         </action>
@@ -1122,6 +1142,7 @@
             <when state="dead: `" output="Ò"/>
             <when state="dead: ~" output="Õ"/>
             <when state="dead: ¨" output="Ö"/>
+            <when state="dead: ¯" output="Ō"/>
             <when state="dead: ´" output="Ó"/>
             <when state="dead: ˇ" output="Ǒ"/>
         </action>
@@ -1142,6 +1163,7 @@
         </action>
         <action id="T">
             <when state="none" output="T"/>
+            <when state="dead: ¯" output="Ŧ"/>
             <when state="dead: ˇ" output="Ť"/>
         </action>
         <action id="U">
@@ -1150,6 +1172,7 @@
             <when state="dead: `" output="Ù"/>
             <when state="dead: ~" output="Ũ"/>
             <when state="dead: ¨" output="Ü"/>
+            <when state="dead: ¯" output="Ū"/>
             <when state="dead: ´" output="Ú"/>
             <when state="dead: ˇ" output="Ǔ"/>
             <when state="dead: ˚" output="Ů"/>
@@ -1164,6 +1187,7 @@
             <when state="dead: ^" output="Ŷ"/>
             <when state="dead: ~" output="Ỹ"/>
             <when state="dead: ¨" output="Ÿ"/>
+            <when state="dead: ¯" output="Ȳ"/>
             <when state="dead: ´" output="Ý"/>
         </action>
         <action id="Z">
@@ -1185,6 +1209,7 @@
             <when state="dead: ~" output="ã"/>
             <when state="dead: ¨" output="ä"/>
             <when state="dead: ´" output="á"/>
+            <when state="dead: ¯" output="ā"/>
             <when state="dead: ˇ" output="ǎ"/>
             <when state="dead: ˚" output="å"/>
         </action>
@@ -1201,6 +1226,7 @@
         </action>
         <action id="d">
             <when state="none" output="d"/>
+            <when state="dead: ¯" output="đ"/>
             <when state="dead: ˇ" output="ď"/>
         </action>
         <action id="e">
@@ -1208,6 +1234,7 @@
             <when state="dead: ^" output="ê"/>
             <when state="dead: `" output="è"/>
             <when state="dead: ¨" output="ë"/>
+            <when state="dead: ¯" output="ē"/>
             <when state="dead: ´" output="é"/>
             <when state="dead: ˇ" output="ě"/>
             <when state="dead: ˚" output="ė"/>
@@ -1215,6 +1242,7 @@
         <action id="g">
             <when state="none" output="g"/>
             <when state="dead: ^" output="ĝ"/>
+            <when state="dead: ¯" output="ḡ"/>
             <when state="dead: ´" output="ǵ"/>
             <when state="dead: ˇ" output="ǧ"/>
             <when state="dead: ˚" output="ġ"/>
@@ -1222,6 +1250,7 @@
         <action id="h">
             <when state="none" output="h"/>
             <when state="dead: ^" output="ĥ"/>
+            <when state="dead: ¯" output="ħ"/>
             <when state="dead: ˇ" output="ȟ"/>
         </action>
         <action id="i">
@@ -1230,6 +1259,7 @@
             <when state="dead: `" output="ì"/>
             <when state="dead: ~" output="ĩ"/>
             <when state="dead: ¨" output="ï"/>
+            <when state="dead: ¯" output="ī"/>
             <when state="dead: ´" output="í"/>
             <when state="dead: ˇ" output="ǐ"/>
         </action>
@@ -1245,6 +1275,7 @@
         </action>
         <action id="l">
             <when state="none" output="l"/>
+            <when state="dead: ¯" output="ḻ"/>
             <when state="dead: ´" output="ł"/>
             <when state="dead: ˇ" output="ľ"/>
         </action>
@@ -1258,6 +1289,7 @@
             <when state="dead: `" output="ò"/>
             <when state="dead: ~" output="õ"/>
             <when state="dead: ¨" output="ö"/>
+            <when state="dead: ¯" output="ō"/>
             <when state="dead: ´" output="ó"/>
             <when state="dead: ˇ" output="ǒ"/>
         </action>
@@ -1278,6 +1310,7 @@
         </action>
         <action id="t">
             <when state="none" output="t"/>
+            <when state="dead: ¯" output="ŧ"/>
             <when state="dead: ˇ" output="ť"/>
         </action>
         <action id="u">
@@ -1286,6 +1319,7 @@
             <when state="dead: `" output="ù"/>
             <when state="dead: ~" output="ũ"/>
             <when state="dead: ¨" output="ü"/>
+            <when state="dead: ¯" output="ū"/>
             <when state="dead: ´" output="ú"/>
             <when state="dead: ˇ" output="ǔ"/>
             <when state="dead: ˚" output="ů"/>
@@ -1301,6 +1335,7 @@
             <when state="dead: ^" output="ŷ"/>
             <when state="dead: ~" output="ỹ"/>
             <when state="dead: ¨" output="ÿ"/>
+            <when state="dead: ¯" output="ȳ"/>
             <when state="dead: ´" output="ý"/>
             <when state="dead: ˚" output="ẙ"/>
         </action>
@@ -1327,6 +1362,7 @@
         </action>
         <action id="Æ">
             <when state="none" output="Æ"/>
+            <when state="dead: ¯" output="Ǣ"/>
             <when state="dead: ´" output="Ǽ"/>
         </action>
         <action id="Ø">
@@ -1335,6 +1371,7 @@
         </action>
         <action id="æ">
             <when state="none" output="æ"/>
+            <when state="dead: ¯" output="ǣ"/>
             <when state="dead: ´" output="ǽ"/>
         </action>
         <action id="ø">

--- a/EurKEY.keylayout
+++ b/EurKEY.keylayout
@@ -53,11 +53,11 @@
             <key code="8" action="c"/>
             <key code="9" output="v"/>
             <key code="10" output="§"/>
-            <key code="11" output="b"/>
+            <key code="11" action="b"/>
             <key code="12" output="q"/>
             <key code="13" action="w"/>
             <key code="14" action="e"/>
-            <key code="15" output="r"/>
+            <key code="15" action="r"/>
             <key code="16" action="y"/>
             <key code="17" output="t"/>
             <key code="18" output="1"/>
@@ -77,18 +77,18 @@
             <key code="32" action="u"/>
             <key code="33" output="["/>
             <key code="34" action="i"/>
-            <key code="35" output="p"/>
+            <key code="35" action="p"/>
             <key code="36" output="&#x000D;"/>
-            <key code="37" output="l"/>
+            <key code="37" action="l"/>
             <key code="38" action="j"/>
             <key code="39" output="&#x0027;"/>
-            <key code="40" output="k"/>
+            <key code="40" action="k"/>
             <key code="41" output=";"/>
             <key code="42" output="\"/>
             <key code="43" output=","/>
             <key code="44" output="/"/>
             <key code="45" action="16"/>
-            <key code="46" output="m"/>
+            <key code="46" action="m"/>
             <key code="47" output="."/>
             <key code="48" output="&#x0009;"/>
             <key code="49" action="5"/>
@@ -165,11 +165,11 @@
             <key code="8" action="C"/>
             <key code="9" output="V"/>
             <key code="10" output="±"/>
-            <key code="11" output="B"/>
+            <key code="11" action="B"/>
             <key code="12" output="Q"/>
             <key code="13" action="W"/>
             <key code="14" action="E"/>
-            <key code="15" output="R"/>
+            <key code="15" action="R"/>
             <key code="16" action="Y"/>
             <key code="17" output="T"/>
             <key code="18" output="!"/>
@@ -189,18 +189,18 @@
             <key code="32" action="U"/>
             <key code="33" output="{"/>
             <key code="34" action="I"/>
-            <key code="35" output="P"/>
+            <key code="35" action="P"/>
             <key code="36" output="&#x000D;"/>
-            <key code="37" output="L"/>
+            <key code="37" action="L"/>
             <key code="38" action="J"/>
             <key code="39" output="&#x0022;"/>
-            <key code="40" output="K"/>
+            <key code="40" action="K"/>
             <key code="41" output=":"/>
             <key code="42" output="|"/>
             <key code="43" output="&#x003C;"/>
             <key code="44" output="?"/>
             <key code="45" action="9"/>
-            <key code="46" output="M"/>
+            <key code="46" action="M"/>
             <key code="47" output="&#x003E;"/>
             <key code="48" output="&#x0009;"/>
             <key code="49" action="5"/>
@@ -277,11 +277,11 @@
             <key code="8" action="C"/>
             <key code="9" output="V"/>
             <key code="10" output="§"/>
-            <key code="11" output="B"/>
+            <key code="11" action="B"/>
             <key code="12" output="Q"/>
             <key code="13" action="W"/>
             <key code="14" action="E"/>
-            <key code="15" output="R"/>
+            <key code="15" action="R"/>
             <key code="16" action="Y"/>
             <key code="17" output="T"/>
             <key code="18" output="1"/>
@@ -301,18 +301,18 @@
             <key code="32" action="U"/>
             <key code="33" output="["/>
             <key code="34" action="I"/>
-            <key code="35" output="P"/>
+            <key code="35" action="P"/>
             <key code="36" output="&#x000D;"/>
-            <key code="37" output="L"/>
+            <key code="37" action="L"/>
             <key code="38" action="J"/>
             <key code="39" output="&#x0027;"/>
-            <key code="40" output="K"/>
+            <key code="40" action="K"/>
             <key code="41" output=";"/>
             <key code="42" output="\"/>
             <key code="43" output=","/>
             <key code="44" output="/"/>
             <key code="45" action="9"/>
-            <key code="46" output="M"/>
+            <key code="46" action="M"/>
             <key code="47" output="."/>
             <key code="48" output="&#x0009;"/>
             <key code="49" action="5"/>
@@ -390,7 +390,7 @@
             <key code="9" output="ì"/>
             <key code="10" output="§"/>
             <key code="11" output="í"/>
-            <key code="12" output="æ"/>
+            <key code="12" action="æ"/>
             <key code="13" output="å"/>
             <key code="14" output="ë"/>
             <key code="15" output="ý"/>
@@ -415,7 +415,7 @@
             <key code="34" output="ï"/>
             <key code="35" output="œ"/>
             <key code="36" output="&#x000D;"/>
-            <key code="37" output="ø"/>
+            <key code="37" action="ø"/>
             <key code="38" output="ú"/>
             <key code="39" action="´"/>
             <key code="40" output="ĳ"/>
@@ -502,7 +502,7 @@
             <key code="9" output="Ì"/>
             <key code="10" output="±"/>
             <key code="11" output="Í"/>
-            <key code="12" output="Æ"/>
+            <key code="12" action="Æ"/>
             <key code="13" output="Å"/>
             <key code="14" output="Ë"/>
             <key code="15" output="Ý"/>
@@ -527,7 +527,7 @@
             <key code="34" output="Ï"/>
             <key code="35" output="Œ"/>
             <key code="36" output="&#x000D;"/>
-            <key code="37" output="Ø"/>
+            <key code="37" action="Ø"/>
             <key code="38" output="Ú"/>
             <key code="39" output="†"/>
             <key code="40" output="Ĳ"/>
@@ -614,7 +614,7 @@
             <key code="9" output="Ì"/>
             <key code="10" output="§"/>
             <key code="11" output="Í"/>
-            <key code="12" output="Æ"/>
+            <key code="12" action="Æ"/>
             <key code="13" output="Å"/>
             <key code="14" output="Ë"/>
             <key code="15" output="Ý"/>
@@ -639,7 +639,7 @@
             <key code="34" output="Ï"/>
             <key code="35" output="Œ"/>
             <key code="36" output="&#x000D;"/>
-            <key code="37" output="Ø"/>
+            <key code="37" action="Ø"/>
             <key code="38" output="Ú"/>
             <key code="39" action="´"/>
             <key code="40" output="Ĳ"/>
@@ -1025,24 +1025,33 @@
             <when state="dead: ^" output="^"/>
             <when state="dead: `" output="`"/>
             <when state="dead: ¨" output="¨"/>
+            <when state="dead: ´" output="´"/>
             <when state="dead: ˚" output="˚"/>
         </action>
         <action id="9">
             <when state="none" output="N"/>
+            <when state="dead: ´" output="Ń"/>
         </action>
         <action id="16">
             <when state="none" output="n"/>
+            <when state="dead: ´" output="ń"/>
         </action>
         <action id="A">
             <when state="none" output="A"/>
             <when state="dead: ^" output="Â"/>
             <when state="dead: `" output="À"/>
             <when state="dead: ¨" output="Ä"/>
+            <when state="dead: ´" output="Á"/>
             <when state="dead: ˚" output="Å"/>
+        </action>
+        <action id="B">
+            <when state="none" output="B"/>
+            <when state="dead: ´" output="Ɓ"/>
         </action>
         <action id="C">
             <when state="none" output="C"/>
             <when state="dead: ^" output="Ĉ"/>
+            <when state="dead: ´" output="Ć"/>
             <when state="dead: ˚" output="Ċ"/>
         </action>
         <action id="E">
@@ -1050,11 +1059,13 @@
             <when state="dead: ^" output="Ê"/>
             <when state="dead: `" output="È"/>
             <when state="dead: ¨" output="Ë"/>
+            <when state="dead: ´" output="É"/>
             <when state="dead: ˚" output="Ė"/>
         </action>
         <action id="G">
             <when state="none" output="G"/>
             <when state="dead: ^" output="Ĝ"/>
+            <when state="dead: ´" output="Ǵ"/>
             <when state="dead: ˚" output="Ġ"/>
         </action>
         <action id="H">
@@ -1066,40 +1077,67 @@
             <when state="dead: ^" output="Î"/>
             <when state="dead: `" output="Ì"/>
             <when state="dead: ¨" output="Ï"/>
+            <when state="dead: ´" output="Í"/>
             <when state="dead: ˚" output="İ"/>
         </action>
         <action id="J">
             <when state="none" output="J"/>
             <when state="dead: ^" output="Ĵ"/>
         </action>
+        <action id="K">
+            <when state="none" output="K"/>
+            <when state="dead: ´" output="Ḱ"/>
+        </action>
+        <action id="L">
+            <when state="none" output="L"/>
+            <when state="dead: ´" output="Ł"/>
+        </action>
+        <action id="M">
+            <when state="none" output="M"/>
+            <when state="dead: ´" output="Ḿ"/>
+        </action>
         <action id="O">
             <when state="none" output="O"/>
             <when state="dead: ^" output="Ô"/>
             <when state="dead: `" output="Ò"/>
             <when state="dead: ¨" output="Ö"/>
+            <when state="dead: ´" output="Ó"/>
+        </action>
+        <action id="P">
+            <when state="none" output="P"/>
+            <when state="dead: ´" output="Ṕ"/>
+        </action>
+        <action id="R">
+            <when state="none" output="R"/>
+            <when state="dead: ´" output="Ŕ"/>
         </action>
         <action id="S">
             <when state="none" output="S"/>
             <when state="dead: ^" output="Ŝ"/>
+            <when state="dead: ´" output="Ś"/>
         </action>
         <action id="U">
             <when state="none" output="U"/>
             <when state="dead: ^" output="Û"/>
             <when state="dead: `" output="Ù"/>
             <when state="dead: ¨" output="Ü"/>
+            <when state="dead: ´" output="Ú"/>
             <when state="dead: ˚" output="Ů"/>
         </action>
         <action id="W">
             <when state="none" output="W"/>
             <when state="dead: ^" output="Ŵ"/>
+            <when state="dead: ´" output="Ẃ"/>
         </action>
         <action id="Y">
             <when state="none" output="Y"/>
             <when state="dead: ^" output="Ŷ"/>
             <when state="dead: ¨" output="Ÿ"/>
+            <when state="dead: ´" output="Ý"/>
         </action>
         <action id="Z">
             <when state="none" output="Z"/>
+            <when state="dead: ´" output="Ź"/>
             <when state="dead: ˚" output="Ż"/>
         </action>
         <action id="^">
@@ -1113,11 +1151,17 @@
             <when state="dead: ^" output="â"/>
             <when state="dead: `" output="à"/>
             <when state="dead: ¨" output="ä"/>
+            <when state="dead: ´" output="á"/>
             <when state="dead: ˚" output="å"/>
+        </action>
+        <action id="b">
+            <when state="none" output="b"/>
+            <when state="dead: ´" output="ɓ"/>
         </action>
         <action id="c">
             <when state="none" output="c"/>
             <when state="dead: ^" output="ĉ"/>
+            <when state="dead: ´" output="ć"/>
             <when state="dead: ˚" output="ċ"/>
         </action>
         <action id="e">
@@ -1125,11 +1169,13 @@
             <when state="dead: ^" output="ê"/>
             <when state="dead: `" output="è"/>
             <when state="dead: ¨" output="ë"/>
+            <when state="dead: ´" output="é"/>
             <when state="dead: ˚" output="ė"/>
         </action>
         <action id="g">
             <when state="none" output="g"/>
             <when state="dead: ^" output="ĝ"/>
+            <when state="dead: ´" output="ǵ"/>
             <when state="dead: ˚" output="ġ"/>
         </action>
         <action id="h">
@@ -1141,41 +1187,68 @@
             <when state="dead: ^" output="î"/>
             <when state="dead: `" output="ì"/>
             <when state="dead: ¨" output="ï"/>
+            <when state="dead: ´" output="í"/>
         </action>
         <action id="j">
             <when state="none" output="j"/>
             <when state="dead: ^" output="ĵ"/>
+        </action>
+        <action id="k">
+            <when state="none" output="k"/>
+            <when state="dead: ´" output="ḱ"/>
+        </action>
+        <action id="l">
+            <when state="none" output="l"/>
+            <when state="dead: ´" output="ł"/>
+        </action>
+        <action id="m">
+            <when state="none" output="m"/>
+            <when state="dead: ´" output="ḿ"/>
         </action>
         <action id="o">
             <when state="none" output="o"/>
             <when state="dead: ^" output="ô"/>
             <when state="dead: `" output="ò"/>
             <when state="dead: ¨" output="ö"/>
+            <when state="dead: ´" output="ó"/>
+        </action>
+        <action id="p">
+            <when state="none" output="p"/>
+            <when state="dead: ´" output="ṕ"/>
+        </action>
+        <action id="r">
+            <when state="none" output="r"/>
+            <when state="dead: ´" output="ŕ"/>
         </action>
         <action id="s">
             <when state="none" output="s"/>
             <when state="dead: ^" output="ŝ"/>
+            <when state="dead: ´" output="ś"/>
         </action>
         <action id="u">
             <when state="none" output="u"/>
             <when state="dead: ^" output="û"/>
             <when state="dead: `" output="ù"/>
             <when state="dead: ¨" output="ü"/>
+            <when state="dead: ´" output="ú"/>
             <when state="dead: ˚" output="ů"/>
         </action>
         <action id="w">
             <when state="none" output="w"/>
             <when state="dead: ^" output="ŵ"/>
+            <when state="dead: ´" output="ẃ"/>
             <when state="dead: ˚" output="ẘ"/>
         </action>
         <action id="y">
             <when state="none" output="y"/>
             <when state="dead: ^" output="ŷ"/>
             <when state="dead: ¨" output="ÿ"/>
+            <when state="dead: ´" output="ý"/>
             <when state="dead: ˚" output="ẙ"/>
         </action>
         <action id="z">
             <when state="none" output="z"/>
+            <when state="dead: ´" output="ź"/>
             <when state="dead: ˚" output="ż"/>
         </action>
         <action id="~">
@@ -1192,6 +1265,22 @@
         </action>
         <action id="´">
             <when state="none" next="dead: ´"/>
+        </action>
+        <action id="Æ">
+            <when state="none" output="Æ"/>
+            <when state="dead: ´" output="Ǽ"/>
+        </action>
+        <action id="Ø">
+            <when state="none" output="Ø"/>
+            <when state="dead: ´" output="Ǿ"/>
+        </action>
+        <action id="æ">
+            <when state="none" output="æ"/>
+            <when state="dead: ´" output="ǽ"/>
+        </action>
+        <action id="ø">
+            <when state="none" output="ø"/>
+            <when state="dead: ´" output="ǿ"/>
         </action>
         <action id="ˇ">
             <when state="none" next="dead: ˇ"/>

--- a/EurKEY.keylayout
+++ b/EurKEY.keylayout
@@ -490,57 +490,57 @@
             <key code="126" output="&#x001E;"/>
         </keyMap>
         <keyMap index="4">
-            <key code="0" output="Å"/>
-            <key code="1" output="Í"/>
-            <key code="2" output="Î"/>
-            <key code="3" output="Ï"/>
-            <key code="4" output="Ó"/>
-            <key code="5" output="˝"/>
-            <key code="6" output="¸"/>
-            <key code="7" output="˛"/>
+            <key code="0" output="Ä"/>
+            <key code="1" output="§"/>
+            <key code="2" output="Ð"/>
+            <key code="3" output="È"/>
+            <key code="4" output="Ù"/>
+            <key code="5" output="É"/>
+            <key code="6" output="À"/>
+            <key code="7" output="Á"/>
             <key code="8" output="Ç"/>
-            <key code="9" output="◊"/>
+            <key code="9" output="Ì"/>
             <key code="10" output="±"/>
-            <key code="11" output="ı"/>
-            <key code="12" output="Œ"/>
-            <key code="13" output="„"/>
-            <key code="14" output="´"/>
-            <key code="15" output="‰"/>
-            <key code="16" output="Á"/>
-            <key code="17" output="ˇ"/>
-            <key code="18" output="⁄"/>
-            <key code="19" output="€"/>
-            <key code="20" output="‹"/>
-            <key code="21" output="›"/>
-            <key code="22" output="ﬂ"/>
-            <key code="23" output="ﬁ"/>
-            <key code="24" output="±"/>
-            <key code="25" output="·"/>
-            <key code="26" output="‡"/>
-            <key code="27" output="—"/>
-            <key code="28" output="°"/>
-            <key code="29" output="‚"/>
-            <key code="30" output="’"/>
-            <key code="31" output="Ø"/>
-            <key code="32" output="¨"/>
-            <key code="33" output="”"/>
-            <key code="34" output="ˆ"/>
-            <key code="35" output="∏"/>
+            <key code="11" output="Í"/>
+            <key code="12" output="Æ"/>
+            <key code="13" output="Å"/>
+            <key code="14" output="Ë"/>
+            <key code="15" output="Ý"/>
+            <key code="16" output="Ÿ"/>
+            <key code="17" output="Þ"/>
+            <key code="18" output="¹"/>
+            <key code="19" output="²"/>
+            <key code="20" output="³"/>
+            <key code="21" output="¥"/>
+            <key code="22" action="ˇ"/>
+            <key code="23" output="¢"/>
+            <key code="24" output="÷"/>
+            <key code="25" output="‘"/>
+            <key code="26" action="¯"/>
+            <key code="27" output="№"/>
+            <key code="28" output="‚"/>
+            <key code="29" output="’"/>
+            <key code="30" output="›"/>
+            <key code="31" output="Ö"/>
+            <key code="32" output="Ü"/>
+            <key code="33" output="‹"/>
+            <key code="34" output="Ï"/>
+            <key code="35" output="Œ"/>
             <key code="36" output="&#x000D;"/>
-            <key code="37" output="Ò"/>
-            <key code="38" output="Ô"/>
-            <key code="39" output="Æ"/>
-            <key code="40" output=""/>
-            <key code="41" output="Ú"/>
-            <key code="42" output="»"/>
-            <key code="43" output="¯"/>
-            <key code="44" output="¿"/>
-            <key code="45" output="˜"/>
-            <key code="46" output="Â"/>
-            <key code="47" output="˘"/>
+            <key code="37" output="Ø"/>
+            <key code="38" output="Ú"/>
+            <key code="39" output="†"/>
+            <key code="40" output="Ĳ"/>
+            <key code="41" output="·"/>
+            <key code="42" output="¦"/>
+            <key code="43" output="Ò"/>
+            <key code="44" output="…"/>
+            <key code="45" output="Ñ"/>
+            <key code="46" action="√"/>
+            <key code="47" output="Ó"/>
             <key code="48" output="&#x0009;"/>
             <key code="49" output=" "/>
-            <key code="50" output="`"/>
+            <key code="50" action="~"/>
             <key code="51" output="&#x0008;"/>
             <key code="52" output="&#x0003;"/>
             <key code="53" output="&#x001B;"/>
@@ -1085,14 +1085,23 @@
         <action id="`">
             <when state="none" next="dead: `"/>
         </action>
+        <action id="~">
+            <when state="none" next="dead: ~"/>
+        </action>
         <action id="¨">
             <when state="none" next="dead: ¨"/>
         </action>
         <action id="©">
             <when state="none" next="dead: ©"/>
         </action>
+        <action id="¯">
+            <when state="none" next="dead: ¯"/>
+        </action>
         <action id="´">
             <when state="none" next="dead: ´"/>
+        </action>
+        <action id="ˇ">
+            <when state="none" next="dead: ˇ"/>
         </action>
         <action id="˚">
             <when state="none" next="dead: ˚"/>
@@ -1100,15 +1109,22 @@
         <action id="Ω">
             <when state="none" next="dead: Ω"/>
         </action>
+        <action id="√">
+            <when state="none" next="dead: √"/>
+        </action>
     </actions>
     <terminators>
         <when state="dead: ^" output="^"/>
         <when state="dead: `" output="`"/>
+        <when state="dead: ~" output="~"/>
         <when state="dead: ¨" output="¨"/>
         <when state="dead: ©" output="©"/>
+        <when state="dead: ¯" output="¯"/>
         <when state="dead: ´" output="´"/>
+        <when state="dead: ˇ" output="ˇ"/>
         <when state="dead: ˚" output="˚"/>
         <when state="dead: Ω" output="Ω"/>
+        <when state="dead: √" output=" "/>
         <when state="s2" output="`"/>
     </terminators>
 </keyboard>

--- a/EurKEY.keylayout
+++ b/EurKEY.keylayout
@@ -43,22 +43,22 @@
     <keyMapSet id="16c">
         <keyMap index="0">
             <key code="0" action="a"/>
-            <key code="1" output="s"/>
+            <key code="1" action="s"/>
             <key code="2" output="d"/>
             <key code="3" output="f"/>
-            <key code="4" output="h"/>
-            <key code="5" output="g"/>
+            <key code="4" action="h"/>
+            <key code="5" action="g"/>
             <key code="6" output="z"/>
             <key code="7" output="x"/>
-            <key code="8" output="c"/>
+            <key code="8" action="c"/>
             <key code="9" output="v"/>
             <key code="10" output="§"/>
             <key code="11" output="b"/>
             <key code="12" output="q"/>
-            <key code="13" output="w"/>
+            <key code="13" action="w"/>
             <key code="14" action="e"/>
             <key code="15" output="r"/>
-            <key code="16" action="19"/>
+            <key code="16" action="y"/>
             <key code="17" output="t"/>
             <key code="18" output="1"/>
             <key code="19" output="2"/>
@@ -80,7 +80,7 @@
             <key code="35" output="p"/>
             <key code="36" output="&#x000D;"/>
             <key code="37" output="l"/>
-            <key code="38" output="j"/>
+            <key code="38" action="j"/>
             <key code="39" output="&#x0027;"/>
             <key code="40" output="k"/>
             <key code="41" output=";"/>
@@ -155,22 +155,22 @@
         </keyMap>
         <keyMap index="1">
             <key code="0" action="A"/>
-            <key code="1" output="S"/>
+            <key code="1" action="S"/>
             <key code="2" output="D"/>
             <key code="3" output="F"/>
-            <key code="4" output="H"/>
-            <key code="5" output="G"/>
+            <key code="4" action="H"/>
+            <key code="5" action="G"/>
             <key code="6" output="Z"/>
             <key code="7" output="X"/>
-            <key code="8" output="C"/>
+            <key code="8" action="C"/>
             <key code="9" output="V"/>
             <key code="10" output="±"/>
             <key code="11" output="B"/>
             <key code="12" output="Q"/>
-            <key code="13" output="W"/>
+            <key code="13" action="W"/>
             <key code="14" action="E"/>
             <key code="15" output="R"/>
-            <key code="16" action="12"/>
+            <key code="16" action="Y"/>
             <key code="17" output="T"/>
             <key code="18" output="!"/>
             <key code="19" output="@"/>
@@ -192,7 +192,7 @@
             <key code="35" output="P"/>
             <key code="36" output="&#x000D;"/>
             <key code="37" output="L"/>
-            <key code="38" output="J"/>
+            <key code="38" action="J"/>
             <key code="39" output="&#x0022;"/>
             <key code="40" output="K"/>
             <key code="41" output=":"/>
@@ -267,22 +267,22 @@
         </keyMap>
         <keyMap index="2">
             <key code="0" action="A"/>
-            <key code="1" output="S"/>
+            <key code="1" action="S"/>
             <key code="2" output="D"/>
             <key code="3" output="F"/>
-            <key code="4" output="H"/>
-            <key code="5" output="G"/>
+            <key code="4" action="H"/>
+            <key code="5" action="G"/>
             <key code="6" output="Z"/>
             <key code="7" output="X"/>
-            <key code="8" output="C"/>
+            <key code="8" action="C"/>
             <key code="9" output="V"/>
             <key code="10" output="§"/>
             <key code="11" output="B"/>
             <key code="12" output="Q"/>
-            <key code="13" output="W"/>
+            <key code="13" action="W"/>
             <key code="14" action="E"/>
             <key code="15" output="R"/>
-            <key code="16" action="12"/>
+            <key code="16" action="Y"/>
             <key code="17" output="T"/>
             <key code="18" output="1"/>
             <key code="19" output="2"/>
@@ -304,7 +304,7 @@
             <key code="35" output="P"/>
             <key code="36" output="&#x000D;"/>
             <key code="37" output="L"/>
-            <key code="38" output="J"/>
+            <key code="38" action="J"/>
             <key code="39" output="&#x0027;"/>
             <key code="40" output="K"/>
             <key code="41" output=";"/>
@@ -1022,39 +1022,67 @@
     <actions>
         <action id="5">
             <when state="none" output=" "/>
+            <when state="dead: ^" output="^"/>
             <when state="dead: `" output="`"/>
         </action>
         <action id="9">
             <when state="none" output="N"/>
         </action>
-        <action id="12">
-            <when state="none" output="Y"/>
-        </action>
         <action id="16">
             <when state="none" output="n"/>
         </action>
-        <action id="19">
-            <when state="none" output="y"/>
-        </action>
         <action id="A">
             <when state="none" output="A"/>
+            <when state="dead: ^" output="Â"/>
             <when state="dead: `" output="À"/>
+        </action>
+        <action id="C">
+            <when state="none" output="C"/>
+            <when state="dead: ^" output="Ĉ"/>
         </action>
         <action id="E">
             <when state="none" output="E"/>
+            <when state="dead: ^" output="Ê"/>
             <when state="dead: `" output="È"/>
+        </action>
+        <action id="G">
+            <when state="none" output="G"/>
+            <when state="dead: ^" output="Ĝ"/>
+        </action>
+        <action id="H">
+            <when state="none" output="H"/>
+            <when state="dead: ^" output="Ĥ"/>
         </action>
         <action id="I">
             <when state="none" output="I"/>
+            <when state="dead: ^" output="Î"/>
             <when state="dead: `" output="Ì"/>
+        </action>
+        <action id="J">
+            <when state="none" output="J"/>
+            <when state="dead: ^" output="Ĵ"/>
         </action>
         <action id="O">
             <when state="none" output="O"/>
+            <when state="dead: ^" output="Ô"/>
             <when state="dead: `" output="Ò"/>
+        </action>
+        <action id="S">
+            <when state="none" output="S"/>
+            <when state="dead: ^" output="Ŝ"/>
         </action>
         <action id="U">
             <when state="none" output="U"/>
+            <when state="dead: ^" output="Û"/>
             <when state="dead: `" output="Ù"/>
+        </action>
+        <action id="W">
+            <when state="none" output="W"/>
+            <when state="dead: ^" output="Ŵ"/>
+        </action>
+        <action id="Y">
+            <when state="none" output="Y"/>
+            <when state="dead: ^" output="Ŷ"/>
         </action>
         <action id="^">
             <when state="none" next="dead: ^"/>
@@ -1064,23 +1092,56 @@
         </action>
         <action id="a">
             <when state="none" output="a"/>
+            <when state="dead: ^" output="â"/>
             <when state="dead: `" output="à"/>
+        </action>
+        <action id="c">
+            <when state="none" output="c"/>
+            <when state="dead: ^" output="ĉ"/>
         </action>
         <action id="e">
             <when state="none" output="e"/>
+            <when state="dead: ^" output="ê"/>
             <when state="dead: `" output="è"/>
+        </action>
+        <action id="g">
+            <when state="none" output="g"/>
+            <when state="dead: ^" output="ĝ"/>
+        </action>
+        <action id="h">
+            <when state="none" output="h"/>
+            <when state="dead: ^" output="ĥ"/>
         </action>
         <action id="i">
             <when state="none" output="i"/>
+            <when state="dead: ^" output="î"/>
             <when state="dead: `" output="ì"/>
+        </action>
+        <action id="j">
+            <when state="none" output="j"/>
+            <when state="dead: ^" output="ĵ"/>
         </action>
         <action id="o">
             <when state="none" output="o"/>
+            <when state="dead: ^" output="ô"/>
             <when state="dead: `" output="ò"/>
+        </action>
+        <action id="s">
+            <when state="none" output="s"/>
+            <when state="dead: ^" output="ŝ"/>
         </action>
         <action id="u">
             <when state="none" output="u"/>
+            <when state="dead: ^" output="û"/>
             <when state="dead: `" output="ù"/>
+        </action>
+        <action id="w">
+            <when state="none" output="w"/>
+            <when state="dead: ^" output="ŵ"/>
+        </action>
+        <action id="y">
+            <when state="none" output="y"/>
+            <when state="dead: ^" output="ŷ"/>
         </action>
         <action id="~">
             <when state="none" next="dead: ~"/>

--- a/EurKEY.keylayout
+++ b/EurKEY.keylayout
@@ -48,7 +48,7 @@
             <key code="3" output="f"/>
             <key code="4" action="h"/>
             <key code="5" action="g"/>
-            <key code="6" output="z"/>
+            <key code="6" action="z"/>
             <key code="7" output="x"/>
             <key code="8" action="c"/>
             <key code="9" output="v"/>
@@ -160,7 +160,7 @@
             <key code="3" output="F"/>
             <key code="4" action="H"/>
             <key code="5" action="G"/>
-            <key code="6" output="Z"/>
+            <key code="6" action="Z"/>
             <key code="7" output="X"/>
             <key code="8" action="C"/>
             <key code="9" output="V"/>
@@ -272,7 +272,7 @@
             <key code="3" output="F"/>
             <key code="4" action="H"/>
             <key code="5" action="G"/>
-            <key code="6" output="Z"/>
+            <key code="6" action="Z"/>
             <key code="7" output="X"/>
             <key code="8" action="C"/>
             <key code="9" output="V"/>
@@ -1024,6 +1024,7 @@
             <when state="none" output=" "/>
             <when state="dead: ^" output="^"/>
             <when state="dead: `" output="`"/>
+            <when state="dead: ˚" output="˚"/>
         </action>
         <action id="9">
             <when state="none" output="N"/>
@@ -1035,19 +1036,23 @@
             <when state="none" output="A"/>
             <when state="dead: ^" output="Â"/>
             <when state="dead: `" output="À"/>
+            <when state="dead: ˚" output="Å"/>
         </action>
         <action id="C">
             <when state="none" output="C"/>
             <when state="dead: ^" output="Ĉ"/>
+            <when state="dead: ˚" output="Ċ"/>
         </action>
         <action id="E">
             <when state="none" output="E"/>
             <when state="dead: ^" output="Ê"/>
             <when state="dead: `" output="È"/>
+            <when state="dead: ˚" output="Ė"/>
         </action>
         <action id="G">
             <when state="none" output="G"/>
             <when state="dead: ^" output="Ĝ"/>
+            <when state="dead: ˚" output="Ġ"/>
         </action>
         <action id="H">
             <when state="none" output="H"/>
@@ -1057,6 +1062,7 @@
             <when state="none" output="I"/>
             <when state="dead: ^" output="Î"/>
             <when state="dead: `" output="Ì"/>
+            <when state="dead: ˚" output="İ"/>
         </action>
         <action id="J">
             <when state="none" output="J"/>
@@ -1075,6 +1081,7 @@
             <when state="none" output="U"/>
             <when state="dead: ^" output="Û"/>
             <when state="dead: `" output="Ù"/>
+            <when state="dead: ˚" output="Ů"/>
         </action>
         <action id="W">
             <when state="none" output="W"/>
@@ -1083,6 +1090,10 @@
         <action id="Y">
             <when state="none" output="Y"/>
             <when state="dead: ^" output="Ŷ"/>
+        </action>
+        <action id="Z">
+            <when state="none" output="Z"/>
+            <when state="dead: ˚" output="Ż"/>
         </action>
         <action id="^">
             <when state="none" next="dead: ^"/>
@@ -1094,19 +1105,23 @@
             <when state="none" output="a"/>
             <when state="dead: ^" output="â"/>
             <when state="dead: `" output="à"/>
+            <when state="dead: ˚" output="å"/>
         </action>
         <action id="c">
             <when state="none" output="c"/>
             <when state="dead: ^" output="ĉ"/>
+            <when state="dead: ˚" output="ċ"/>
         </action>
         <action id="e">
             <when state="none" output="e"/>
             <when state="dead: ^" output="ê"/>
             <when state="dead: `" output="è"/>
+            <when state="dead: ˚" output="ė"/>
         </action>
         <action id="g">
             <when state="none" output="g"/>
             <when state="dead: ^" output="ĝ"/>
+            <when state="dead: ˚" output="ġ"/>
         </action>
         <action id="h">
             <when state="none" output="h"/>
@@ -1134,14 +1149,21 @@
             <when state="none" output="u"/>
             <when state="dead: ^" output="û"/>
             <when state="dead: `" output="ù"/>
+            <when state="dead: ˚" output="ů"/>
         </action>
         <action id="w">
             <when state="none" output="w"/>
             <when state="dead: ^" output="ŵ"/>
+            <when state="dead: ˚" output="ẘ"/>
         </action>
         <action id="y">
             <when state="none" output="y"/>
             <when state="dead: ^" output="ŷ"/>
+            <when state="dead: ˚" output="ẙ"/>
+        </action>
+        <action id="z">
+            <when state="none" output="z"/>
+            <when state="dead: ˚" output="ż"/>
         </action>
         <action id="~">
             <when state="none" next="dead: ~"/>

--- a/EurKEY.keylayout
+++ b/EurKEY.keylayout
@@ -89,7 +89,7 @@
             <key code="44" output="/"/>
             <key code="45" action="n"/>
             <key code="46" action="m"/>
-            <key code="47" output="."/>
+            <key code="47" action="."/>
             <key code="48" output="&#x0009;"/>
             <key code="49" action="space"/>
             <key code="50" output="`"/>
@@ -195,16 +195,16 @@
             <key code="38" action="J"/>
             <key code="39" action="&#x0022;"/>
             <key code="40" action="K"/>
-            <key code="41" output=":"/>
-            <key code="42" output="|"/>
-            <key code="43" output="&#x003C;"/>
+            <key code="41" action=":"/>
+            <key code="42" action="|"/>
+            <key code="43" action="&#x003C;"/>
             <key code="44" output="?"/>
             <key code="45" action="N"/>
             <key code="46" action="M"/>
-            <key code="47" output="&#x003E;"/>
+            <key code="47" action="&#x003E;"/>
             <key code="48" output="&#x0009;"/>
             <key code="49" action="space"/>
-            <key code="50" output="~"/>
+            <key code="50" action="~"/>
             <key code="51" output="&#x0008;"/>
             <key code="52" output="&#x0003;"/>
             <key code="53" output="&#x001B;"/>
@@ -293,7 +293,7 @@
             <key code="24" action="="/>
             <key code="25" action="9"/>
             <key code="26" action="7"/>
-            <key code="27" output="-"/>
+            <key code="27" action="-"/>
             <key code="28" action="8"/>
             <key code="29" action="0"/>
             <key code="30" output="]"/>
@@ -540,7 +540,7 @@
             <key code="47" output="Ó"/>
             <key code="48" output="&#x0009;"/>
             <key code="49" output=" "/>
-            <key code="50" action="~"/>
+            <key code="50" action="~ option"/>
             <key code="51" output="&#x0008;"/>
             <key code="52" output="&#x0003;"/>
             <key code="53" output="&#x001B;"/>
@@ -1023,6 +1023,7 @@
         <action id="!">
             <when state="none" output="!"/>
             <when state="dead: Ω" output="₁"/>
+            <when state="dead: √" output="≠"/>
         </action>
         <action id="#">
             <when state="none" output="#"/>
@@ -1035,18 +1036,30 @@
         <action id="%">
             <when state="none" output="%"/>
             <when state="dead: Ω" output="₅"/>
+            <when state="dead: √" output="‰"/>
+        </action>
+        <action id="&#x003C;">
+            <when state="none" output="&#x003C;"/>
+            <when state="dead: √" output="≤"/>
+        </action>
+        <action id="&#x003E;">
+            <when state="none" output="&#x003E;"/>
+            <when state="dead: √" output="≥"/>
         </action>
         <action id="&#x0022;">
             <when state="none" output="&#x0022;"/>
             <when state="dead: Ω" output="₊"/>
+            <when state="dead: √" output="″"/>
         </action>
         <action id="&#x0026;">
             <when state="none" output="&#x0026;"/>
             <when state="dead: Ω" output="₇"/>
+            <when state="dead: √" output="∧"/>
         </action>
         <action id="&#x0027;">
             <when state="none" output="&#x0027;"/>
             <when state="dead: Ω" output="₌"/>
+            <when state="dead: √" output="′"/>
         </action>
         <action id="(">
             <when state="none" output="("/>
@@ -1059,15 +1072,22 @@
         <action id="*">
             <when state="none" output="*"/>
             <when state="dead: Ω" output="₈"/>
+            <when state="dead: √" output="⊗"/>
         </action>
         <action id="+">
             <when state="none" output="+"/>
             <when state="dead: ©" output="⇔"/>
             <when state="dead: Ω" output="⁺"/>
+            <when state="dead: √" output="⊕"/>
         </action>
         <action id="-">
             <when state="none" output="-"/>
             <when state="dead: Ω" output="⁻"/>
+            <when state="dead: √" output="±"/>
+        </action>
+        <action id=".">
+            <when state="none" output="."/>
+            <when state="dead: √" output="⋅"/>
         </action>
         <action id="0">
             <when state="none" output="0"/>
@@ -1090,11 +1110,13 @@
             <when state="dead: ©" output="¾"/>
             <when state="dead: ¯" output="—"/>
             <when state="dead: Ω" output="³"/>
+            <when state="dead: √" output="∛"/>
         </action>
         <action id="4">
             <when state="none" output="4"/>
             <when state="dead: ©" output="⅓"/>
             <when state="dead: Ω" output="⁴"/>
+            <when state="dead: √" output="∜"/>
         </action>
         <action id="5">
             <when state="none" output="5"/>
@@ -1115,23 +1137,32 @@
         <action id="7">
             <when state="none" output="7"/>
             <when state="dead: Ω" output="⁷"/>
+            <when state="dead: √" output="∡"/>
         </action>
         <action id="8">
             <when state="none" output="8"/>
             <when state="dead: Ω" output="⁸"/>
+            <when state="dead: √" output="∠"/>
         </action>
         <action id="9">
             <when state="none" output="9"/>
             <when state="dead: Ω" output="⁹"/>
+            <when state="dead: √" output="∟"/>
+        </action>
+        <action id=":">
+            <when state="none" output=":"/>
+            <when state="dead: √" output="∴"/>
         </action>
         <action id=";">
             <when state="none" output=";"/>
             <when state="dead: Ω" output="₋"/>
+            <when state="dead: √" output="∵"/>
         </action>
         <action id="=">
             <when state="none" output="="/>
             <when state="dead: ©" output="↔"/>
             <when state="dead: Ω" output="⁼"/>
+            <when state="dead: √" output="≝"/>
         </action>
         <action id="@">
             <when state="none" output="@"/>
@@ -1148,11 +1179,13 @@
             <when state="dead: ˇ" output="Ǎ"/>
             <when state="dead: ˚" output="Å"/>
             <when state="dead: Ω" output="Α"/>
+            <when state="dead: √" output="∀"/>
         </action>
         <action id="B">
             <when state="none" output="B"/>
             <when state="dead: ´" output="Ɓ"/>
             <when state="dead: Ω" output="Β"/>
+            <when state="dead: √" output="⊇"/>
         </action>
         <action id="C">
             <when state="none" output="C"/>
@@ -1162,12 +1195,14 @@
             <when state="dead: ˇ" output="Č"/>
             <when state="dead: ˚" output="Ċ"/>
             <when state="dead: Ω" output="Χ"/>
+            <when state="dead: √" output="ℂ"/>
         </action>
         <action id="D">
             <when state="none" output="D"/>
             <when state="dead: ¯" output="Đ"/>
             <when state="dead: ˇ" output="Ď"/>
             <when state="dead: Ω" output="Δ"/>
+            <when state="dead: √" output="∇"/>
         </action>
         <action id="E">
             <when state="none" output="E"/>
@@ -1179,10 +1214,12 @@
             <when state="dead: ˇ" output="Ě"/>
             <when state="dead: ˚" output="Ė"/>
             <when state="dead: Ω" output="Ε"/>
+            <when state="dead: √" output="∃"/>
         </action>
         <action id="F">
             <when state="none" output="F"/>
             <when state="dead: Ω" output="Φ"/>
+            <when state="dead: √" output="∎"/>
         </action>
         <action id="G">
             <when state="none" output="G"/>
@@ -1192,6 +1229,7 @@
             <when state="dead: ˇ" output="Ǧ"/>
             <when state="dead: ˚" output="Ġ"/>
             <when state="dead: Ω" output="Γ"/>
+            <when state="dead: √" output="⊃"/>
         </action>
         <action id="H">
             <when state="none" output="H"/>
@@ -1200,6 +1238,7 @@
             <when state="dead: ¯" output="Ħ"/>
             <when state="dead: ˇ" output="Ȟ"/>
             <when state="dead: Ω" output="Θ"/>
+            <when state="dead: √" output="⊅"/>
         </action>
         <action id="I">
             <when state="none" output="I"/>
@@ -1226,6 +1265,7 @@
             <when state="dead: ´" output="Ḱ"/>
             <when state="dead: ˇ" output="Ǩ"/>
             <when state="dead: Ω" output="Κ"/>
+            <when state="dead: √" output="∌"/>
         </action>
         <action id="L">
             <when state="none" output="L"/>
@@ -1234,12 +1274,14 @@
             <when state="dead: ´" output="Ł"/>
             <when state="dead: ˇ" output="Ľ"/>
             <when state="dead: Ω" output="Λ"/>
+            <when state="dead: √" output="∦"/>
         </action>
         <action id="M">
             <when state="none" output="M"/>
             <when state="dead: ©" output="⇘"/>
             <when state="dead: ´" output="Ḿ"/>
             <when state="dead: Ω" output="Μ"/>
+            <when state="dead: √" output="∉"/>
         </action>
         <action id="N">
             <when state="none" output="N"/>
@@ -1248,6 +1290,7 @@
             <when state="dead: ´" output="Ń"/>
             <when state="dead: ˇ" output="Ň"/>
             <when state="dead: Ω" output="Ν"/>
+            <when state="dead: √" output="ℕ"/>
         </action>
         <action id="O">
             <when state="none" output="O"/>
@@ -1259,16 +1302,19 @@
             <when state="dead: ´" output="Ó"/>
             <when state="dead: ˇ" output="Ǒ"/>
             <when state="dead: Ω" output="Ο"/>
+            <when state="dead: √" output="∅"/>
         </action>
         <action id="P">
             <when state="none" output="P"/>
             <when state="dead: ©" output="℗"/>
             <when state="dead: ´" output="Ṕ"/>
             <when state="dead: Ω" output="Π"/>
+            <when state="dead: √" output="ℙ"/>
         </action>
         <action id="Q">
             <when state="none" output="Q"/>
             <when state="dead: Ω" output="Ω"/>
+            <when state="dead: √" output="ℚ"/>
         </action>
         <action id="R">
             <when state="none" output="R"/>
@@ -1276,6 +1322,7 @@
             <when state="dead: ´" output="Ŕ"/>
             <when state="dead: ˇ" output="Ř"/>
             <when state="dead: Ω" output="Ρ"/>
+            <when state="dead: √" output="ℝ"/>
         </action>
         <action id="S">
             <when state="none" output="S"/>
@@ -1284,6 +1331,7 @@
             <when state="dead: ´" output="Ś"/>
             <when state="dead: ˇ" output="Š"/>
             <when state="dead: Ω" output="Σ"/>
+            <when state="dead: √" output="∫"/>
         </action>
         <action id="T">
             <when state="none" output="T"/>
@@ -1304,6 +1352,7 @@
             <when state="dead: ˇ" output="Ǔ"/>
             <when state="dead: ˚" output="Ů"/>
             <when state="dead: Ω" output="Ω"/>
+            <when state="dead: √" output="∖"/>
         </action>
         <action id="V">
             <when state="none" output="V"/>
@@ -1318,6 +1367,7 @@
         <action id="X">
             <when state="none" output="X"/>
             <when state="dead: Ω" output="Ξ"/>
+            <when state="dead: √" output="∄"/>
         </action>
         <action id="Y">
             <when state="none" output="Y"/>
@@ -1334,6 +1384,7 @@
             <when state="dead: ˇ" output="Ž"/>
             <when state="dead: ˚" output="Ż"/>
             <when state="dead: Ω" output="Ζ"/>
+            <when state="dead: √" output="ℤ"/>
         </action>
         <action id="[">
             <when state="none" output="["/>
@@ -1346,6 +1397,7 @@
         <action id="^">
             <when state="none" output="^"/>
             <when state="dead: Ω" output="₆"/>
+            <when state="dead: √" output="℘"/>
         </action>
         <action id="_">
             <when state="none" output="_"/>
@@ -1369,6 +1421,7 @@
             <when state="none" output="b"/>
             <when state="dead: ´" output="ɓ"/>
             <when state="dead: Ω" output="β"/>
+            <when state="dead: √" output="⊆"/>
         </action>
         <action id="c">
             <when state="none" output="c"/>
@@ -1378,12 +1431,14 @@
             <when state="dead: ˇ" output="č"/>
             <when state="dead: ˚" output="ċ"/>
             <when state="dead: Ω" output="χ"/>
+            <when state="dead: √" output="∝"/>
         </action>
         <action id="d">
             <when state="none" output="d"/>
             <when state="dead: ¯" output="đ"/>
             <when state="dead: ˇ" output="ď"/>
             <when state="dead: Ω" output="δ"/>
+            <when state="dead: √" output="Δ"/>
         </action>
         <action id="e">
             <when state="none" output="e"/>
@@ -1399,6 +1454,7 @@
         <action id="f">
             <when state="none" output="f"/>
             <when state="dead: Ω" output="φ"/>
+            <when state="dead: √" output="ƒ"/>
         </action>
         <action id="g">
             <when state="none" output="g"/>
@@ -1408,6 +1464,7 @@
             <when state="dead: ˇ" output="ǧ"/>
             <when state="dead: ˚" output="ġ"/>
             <when state="dead: Ω" output="γ"/>
+            <when state="dead: √" output="⊂"/>
         </action>
         <action id="h">
             <when state="none" output="h"/>
@@ -1416,6 +1473,7 @@
             <when state="dead: ¯" output="ħ"/>
             <when state="dead: ˇ" output="ȟ"/>
             <when state="dead: Ω" output="θ"/>
+            <when state="dead: √" output="⊄"/>
         </action>
         <action id="i">
             <when state="none" output="i"/>
@@ -1428,6 +1486,7 @@
             <when state="dead: ´" output="í"/>
             <when state="dead: ˇ" output="ǐ"/>
             <when state="dead: Ω" output="η"/>
+            <when state="dead: √" output="∞"/>
         </action>
         <action id="j">
             <when state="none" output="j"/>
@@ -1442,6 +1501,7 @@
             <when state="dead: ´" output="ḱ"/>
             <when state="dead: ˇ" output="ǩ"/>
             <when state="dead: Ω" output="κ"/>
+            <when state="dead: √" output="∋"/>
         </action>
         <action id="l">
             <when state="none" output="l"/>
@@ -1450,12 +1510,14 @@
             <when state="dead: ´" output="ł"/>
             <when state="dead: ˇ" output="ľ"/>
             <when state="dead: Ω" output="λ"/>
+            <when state="dead: √" output="∥"/>
         </action>
         <action id="m">
             <when state="none" output="m"/>
             <when state="dead: ©" output="↘"/>
             <when state="dead: ´" output="ḿ"/>
             <when state="dead: Ω" output="μ"/>
+            <when state="dead: √" output="∈"/>
         </action>
         <action id="n">
             <when state="none" output="n"/>
@@ -1464,6 +1526,7 @@
             <when state="dead: ´" output="ń"/>
             <when state="dead: ˇ" output="ň"/>
             <when state="dead: Ω" output="ν"/>
+            <when state="dead: √" output="ⁿ"/>
         </action>
         <action id="o">
             <when state="none" output="o"/>
@@ -1475,12 +1538,14 @@
             <when state="dead: ´" output="ó"/>
             <when state="dead: ˇ" output="ǒ"/>
             <when state="dead: Ω" output="ο"/>
+            <when state="dead: √" output="∘"/>
         </action>
         <action id="p">
             <when state="none" output="p"/>
             <when state="dead: ©" output="℗"/>
             <when state="dead: ´" output="ṕ"/>
             <when state="dead: Ω" output="π"/>
+            <when state="dead: √" output="∂"/>
         </action>
         <action id="q">
             <when state="none" output="q"/>
@@ -1492,6 +1557,7 @@
             <when state="dead: ´" output="ŕ"/>
             <when state="dead: ˇ" output="ř"/>
             <when state="dead: Ω" output="ρ"/>
+            <when state="dead: √" output="√"/>
         </action>
         <action id="s">
             <when state="none" output="s"/>
@@ -1500,6 +1566,7 @@
             <when state="dead: ´" output="ś"/>
             <when state="dead: ˇ" output="š"/>
             <when state="dead: Ω" output="σ"/>
+            <when state="dead: √" output="∩"/>
         </action>
         <action id="space">
             <when state="none" output=" "/>
@@ -1512,6 +1579,7 @@
             <when state="dead: ´" output="´"/>
             <when state="dead: ˇ" output="ˇ"/>
             <when state="dead: ˚" output="˚"/>
+            <when state="dead: √" output="√"/>
         </action>
         <action id="t">
             <when state="none" output="t"/>
@@ -1532,6 +1600,7 @@
             <when state="dead: ˇ" output="ǔ"/>
             <when state="dead: ˚" output="ů"/>
             <when state="dead: Ω" output="ω"/>
+            <when state="dead: √" output="∪"/>
         </action>
         <action id="v">
             <when state="none" output="v"/>
@@ -1564,16 +1633,25 @@
             <when state="dead: ˇ" output="ž"/>
             <when state="dead: ˚" output="ż"/>
             <when state="dead: Ω" output="ζ"/>
+            <when state="dead: √" output="↯"/>
         </action>
         <action id="{">
             <when state="none" output="{"/>
             <when state="dead: Ω" output="₍"/>
+        </action>
+        <action id="|">
+            <when state="none" output="|"/>
+            <when state="dead: √" output="∨"/>
         </action>
         <action id="}">
             <when state="none" output="}"/>
             <when state="dead: Ω" output="₎"/>
         </action>
         <action id="~">
+            <when state="none" output="~"/>
+            <when state="dead: √" output="≈"/>
+        </action>
+        <action id="~ option">
             <when state="none" next="dead: ~"/>
         </action>
         <action id="¨">

--- a/EurKEY.keylayout
+++ b/EurKEY.keylayout
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE keyboard PUBLIC "" "file://localhost/System/Library/DTDs/KeyboardLayout.dtd">
-<keyboard group="0" id="14844" name="U.S." maxout="1">
+<keyboard group="0" id="14844" name="EurKEY v1.1" maxout="1">
     <layouts>
         <layout first="0" last="17" modifiers="f4" mapSet="16c"/>
         <layout first="18" last="18" modifiers="f4" mapSet="994"/>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The Keyboard Layout for Europeans, Coders and Translators - Version for Mac OS X
 This is a port of the [EurKEY Keyboard layout](http://eurkey.steffen.bruentjen.eu/), which features a QWERTY baseline layout (=good access to braces etc.) 
 with quick access to commonly used accented characters and Umlauts.
 
-**Status**: The basic layout is complete, but some deadkeys are not mapped yet. Feel free to contribute the missing mapping.
+**Status**: The whole layout should be mapped now. Please report if you find any missing characters.
 
 
 Install


### PR DESCRIPTION
I mapped all the EurKEY v1.1 mappings (plus a few extra accented characters — but still a strict superset). All keys should be 100% compatible with Windows EurKEY now (Command+Option mappings, which don't exist in Windows, were left as they are in the standard U.S. layout).
